### PR TITLE
Remove CI-added compiler warning flags on regular builds

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -225,15 +225,6 @@ set(DASHBOARD_SHARED_LINKER_FLAGS "")
 set(DASHBOARD_STATIC_LINKER_FLAGS "")
 set(DASHBOARD_VERBOSE_MAKEFILE OFF)
 
-# set compiler flags for regular builds
-if(NOT DEFINED ENV{ghprbPullId})
-  if("$ENV{compiler}" MATCHES "clang" OR "$ENV{compiler}" MATCHES "gcc")
-    set(DASHBOARD_WARNING_FLAGS "-pedantic -Wall -Wextra")
-    set(DASHBOARD_C_FLAGS "${DASHBOARD_WARNING_FLAGS} ${DASHBOARD_C_FLAGS}")
-    set(DASHBOARD_CXX_FLAGS "${DASHBOARD_WARNING_FLAGS} ${DASHBOARD_CXX_FLAGS}")
-  endif()
-endif()
-
 if("$ENV{compiler}" MATCHES "include-what-you-use")
   set(DASHBOARD_INSTALL OFF)
   set(DASHBOARD_TEST OFF)


### PR DESCRIPTION
This is toward RobotLocomotion/drake#1936, where these will reappear under `drake-distro/drake/CMakeLists.txt` instead.

PTAL and see if this looks like the correct starting point.

/cc @david-german-tri