### PR TITLE
Use 'build' instead of 'pod-build' for binary dir

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -160,7 +160,7 @@ elseif(COMPILER STREQUAL "msvc-64")
 endif()
 
 set(CTEST_SOURCE_DIRECTORY "${DASHBOARD_WORKSPACE}")
-set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/pod-build")
+set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/build")
 
 if(WIN32)
   if(COMPILER MATCHES "ninja")
@@ -403,10 +403,10 @@ if(COMPILER STREQUAL "cpplint")
       "*** CTest Result: FAILURE BECAUSE CPPLINT WAS NOT FOUND")
   endif()
   set(CTEST_BUILD_COMMAND
-    "${CMAKE_CURRENT_LIST_DIR}/cpplint_wrapper.py --cpplint=${DASHBOARD_CPPLINT_COMMAND} --excludes=(\\.git|doc|pod-build|thirdParty) ${DASHBOARD_WORKSPACE}/drake")
+    "${CMAKE_CURRENT_LIST_DIR}/cpplint_wrapper.py --cpplint=${DASHBOARD_CPPLINT_COMMAND} --excludes=(\\.git|doc|build|thirdParty) ${DASHBOARD_WORKSPACE}/drake")
 endif()
 
-set(DASHBOARD_INSTALL_PREFIX "${DASHBOARD_WORKSPACE}/build")
+set(DASHBOARD_INSTALL_PREFIX "${CTEST_BINARY_DIRECTORY}/install")
 
 # clean out any old installs
 file(REMOVE_RECURSE "${DASHBOARD_INSTALL_PREFIX}")
@@ -457,7 +457,7 @@ if(COMPILER MATCHES "^scan-build")
     "${DASHBOARD_EXTRA_DEBUG_FLAGS} ${DASHBOARD_CXX_FLAGS}")
   set(DASHBOARD_FORTRAN_FLAGS
     "${DASHBOARD_EXTRA_DEBUG_FLAGS} ${DASHBOARD_FORTRAN_FLAGS}")
-  set(DASHBOARD_CCC_ANALYZER_HTML "${DASHBOARD_WORKSPACE}/drake/pod-build/html")
+  set(DASHBOARD_CCC_ANALYZER_HTML "${DASHBOARD_WORKSPACE}/drake/build/html")
   set(ENV{CCC_ANALYZER_HTML} "${DASHBOARD_CCC_ANALYZER_HTML}")
   file(MAKE_DIRECTORY "${DASHBOARD_CCC_ANALYZER_HTML}")
 endif()
@@ -1064,7 +1064,7 @@ else()
 
   # now start the actual drake build
   set(CTEST_SOURCE_DIRECTORY "${DASHBOARD_WORKSPACE}/drake")
-  set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/drake/pod-build")
+  set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/drake/build")
 
   # switch the dashboard to the drake only dashboard
   set(CTEST_PROJECT_NAME "${DASHBOARD_PROJECT_NAME}")


### PR DESCRIPTION
This changes the build and install directories used by CI to ~~match the current build instructions~~ not use the old PODS directories, in order to flush out if anything was making assumptions that those were being used (assumptions which would be wrong for anyone following the current build instructions).

@jamiesnape, @david-german-tri, we might want to have a merge plan for this... it won't surprise me if it breaks something, but ultimately this patch *really* should go in, because any issues resulting from this are likely to bite ordinary users as well. Accordingly, if we can run some tests first, especially on e.g. OS X with MATLAB, we should, and we may want to plan to merge it at a time when we're standing by to try to fix any breakage ASAP rather than having to go through the merge-revert-repeat dance.

(This is also the last remaining part of #9.)