### PR TITLE
Use 'build' instead of 'pod-build' for binary dir (take 2)

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -160,7 +160,8 @@ elseif(COMPILER STREQUAL "msvc-64")
 endif()
 
 set(CTEST_SOURCE_DIRECTORY "${DASHBOARD_WORKSPACE}")
-set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/pod-build")
+set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/build")
+set(DASHBOARD_INSTALL_PREFIX "${CTEST_BINARY_DIRECTORY}/install")
 
 if(WIN32)
   if(COMPILER MATCHES "ninja")
@@ -208,8 +209,8 @@ if(WIN32)
   endif()
   set(PATH
     "${DASHBOARD_WORKSPACE}"
-    "${DASHBOARD_WORKSPACE}/build/bin"
-    "${DASHBOARD_WORKSPACE}/build/lib")
+    "${DASHBOARD_INSTALL_PREFIX}/bin"
+    "${DASHBOARD_INSTALL_PREFIX}/lib")
   foreach(p ${PATH})
     file(TO_NATIVE_PATH "${p}" path)
     list(APPEND paths "${path}")
@@ -403,10 +404,8 @@ if(COMPILER STREQUAL "cpplint")
       "*** CTest Result: FAILURE BECAUSE CPPLINT WAS NOT FOUND")
   endif()
   set(CTEST_BUILD_COMMAND
-    "${CMAKE_CURRENT_LIST_DIR}/cpplint_wrapper.py --cpplint=${DASHBOARD_CPPLINT_COMMAND} --excludes=(\\.git|doc|pod-build|thirdParty) ${DASHBOARD_WORKSPACE}/drake")
+    "${CMAKE_CURRENT_LIST_DIR}/cpplint_wrapper.py --cpplint=${DASHBOARD_CPPLINT_COMMAND} --excludes=(\\.git|doc|build|thirdParty) ${DASHBOARD_WORKSPACE}/drake")
 endif()
-
-set(DASHBOARD_INSTALL_PREFIX "${DASHBOARD_WORKSPACE}/build")
 
 # clean out any old installs
 file(REMOVE_RECURSE "${DASHBOARD_INSTALL_PREFIX}")
@@ -457,7 +456,7 @@ if(COMPILER MATCHES "^scan-build")
     "${DASHBOARD_EXTRA_DEBUG_FLAGS} ${DASHBOARD_CXX_FLAGS}")
   set(DASHBOARD_FORTRAN_FLAGS
     "${DASHBOARD_EXTRA_DEBUG_FLAGS} ${DASHBOARD_FORTRAN_FLAGS}")
-  set(DASHBOARD_CCC_ANALYZER_HTML "${DASHBOARD_WORKSPACE}/drake/pod-build/html")
+  set(DASHBOARD_CCC_ANALYZER_HTML "${DASHBOARD_WORKSPACE}/drake/build/html")
   set(ENV{CCC_ANALYZER_HTML} "${DASHBOARD_CCC_ANALYZER_HTML}")
   file(MAKE_DIRECTORY "${DASHBOARD_CCC_ANALYZER_HTML}")
 endif()
@@ -1064,7 +1063,7 @@ else()
 
   # now start the actual drake build
   set(CTEST_SOURCE_DIRECTORY "${DASHBOARD_WORKSPACE}/drake")
-  set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/drake/pod-build")
+  set(CTEST_BINARY_DIRECTORY "${DASHBOARD_WORKSPACE}/drake/build")
 
   # switch the dashboard to the drake only dashboard
   set(CTEST_PROJECT_NAME "${DASHBOARD_PROJECT_NAME}")

--- a/ctest_publish_documentation.bash
+++ b/ctest_publish_documentation.bash
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 export PATH="/usr/local/bin:${PATH}"
 git clone --quiet --single-branch git@github.com:RobotLocomotion/RobotLocomotion.github.io.git "${WORKSPACE}/gh-pages"
-rsync --archive --delete --exclude=.git --exclude=.gitignore --exclude=LICENSE --exclude=README --quiet "${WORKSPACE}/build/share/doc/" "${WORKSPACE}/gh-pages/"
+rsync --archive --delete --exclude=.git --exclude=.gitignore --exclude=LICENSE --exclude=README --quiet "${WORKSPACE}/install/share/doc/" "${WORKSPACE}/gh-pages/"
 cd "${WORKSPACE}/gh-pages"
 git add --all
 if git diff-index --quiet HEAD; then


### PR DESCRIPTION
See #15. Test windows build: https://drake-cdash.csail.mit.edu/buildSummary.php?buildid=61733 (at least some of the test failures are likely due to firewall issues, but the systemic problem is noticeably fixed).