### PR TITLE
Set OXYGEN_DIR

### DIFF
--- a/driver/configurations/generic.cmake
+++ b/driver/configurations/generic.cmake
@@ -67,6 +67,10 @@ set(DASHBOARD_LONG_RUNNING_TESTS OFF)
 
 if(DOCUMENTATION OR DOCUMENTATION STREQUAL "publish")
   set(DASHBOARD_BUILD_DOCUMENTATION ON)
+
+  if(DOCUMENTATION STREQUAL "publish")
+    set(ENV{OXYGEN_DIR} "/usr/local/oxygen") 
+  endif()
 endif()
 
 if(NOT DEFINED ENV{ghprbPullId})


### PR DESCRIPTION
Depends on RobotLocomotion/drake#3840. Fixes RobotLocomotion/drake#3476.