### PR TITLE
Set build ID on local builds

### DIFF
--- a/run_local.bash
+++ b/run_local.bash
@@ -19,7 +19,7 @@ export provision=false
 export ros=false
 export track=experimental
 
-export BUILD_ID=0
+export BUILD_ID="$(date -u +'%y%j.%H.%M')"
 export JOB_NAME="unix-${compiler}-experimental"
 export NODE_NAME=$(hostname -s)
 export WORKSPACE="${HOME}/workspace/${JOB_NAME}"


### PR DESCRIPTION
Modify `run_local.bash` to set a "unique" build identifier so that the resulting dashboard links will always return exactly and only the builds from a specific run.

This is achieved by creating an identifier that is a function of the current date and time (to minute accuracy) when the script is executed. This is not absolutely guaranteed to be unique, but the chance of collisions is low, and the chance of repeats is also low, and this way the build identifier is more meaningful than simply choosing a random number.