### PR TITLE
Set working directory for run_local.bash

### DIFF
--- a/run_local.bash
+++ b/run_local.bash
@@ -26,5 +26,6 @@ export WORKSPACE="${HOME}/workspace/${JOB_NAME}"
 
 export PATH="/usr/local/bin:${PATH}"
 
+cd /tmp
 ctest -Dbuildname="${JOB_NAME}" -Dsite="${NODE_NAME}" -S "${WORKSPACE}/ci/ctest_driver_script.cmake" --extra-verbose --output-on-failure
 [[ (-e "${WORKSPACE}/SUCCESS" || -e "${WORKSPACE}/UNSTABLE") && ! -e "${WORKSPACE}/FAILURE" ]]


### PR DESCRIPTION
Change `run_local.bash` to set the working directory before running the driver script, in order to catch errors from assuming that the working directory is the directory in which the driver script resides. This is often the case when using the script, but is *not* how actual CI jobs run, which made it easy to overlook bugs until a change is merged. This should help avoid that issue.

The chosen working directory is `/tmp`, which certainly ought to exist. (Also, if it doesn't the command to change the working directory will fail, but without causing the script to fail, so all we lose if there is no `/tmp` for some reason is the protection of not running the script from the user's working directory when `run_local.bash` is called.)