### PR TITLE
Always set up compiler

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -60,9 +60,7 @@ include(${DASHBOARD_DRIVER_DIR}/site.cmake)
 
 # Set up the compiler and build platform
 include(${DASHBOARD_DRIVER_DIR}/platform.cmake)
-if(NOT COMPILER STREQUAL "cpplint")
-  include(${DASHBOARD_DRIVER_DIR}/compiler.cmake)
-endif()
+include(${DASHBOARD_DRIVER_DIR}/compiler.cmake)
 
 # Set up status variables
 set(DASHBOARD_FAILURE OFF)


### PR DESCRIPTION
Don't skip setting up the compiler for cpplint jobs. This is sort of silly, as there is no real reason why cpplint needs to go through all that logic when it isn't going to actually compile anything, but the superbuild enforces a minimum compiler version even for cpplint, so still needs the "right" compiler.