### PR TITLE
Maybe disable Python and/or Fortran

### DIFF
--- a/driver/configurations/coverage.cmake
+++ b/driver/configurations/coverage.cmake
@@ -17,6 +17,7 @@ prepend_flags(DASHBOARD_FORTRAN_FLAGS
 prepend_flags(DASHBOARD_SHARED_LINKER_FLAGS
   ${DASHBOARD_COVERAGE_FLAGS})
 
+# Find coverage tool
 if(COMPILER STREQUAL "clang")
   if(APPLE)
     find_program(DASHBOARD_XCRUN_COMMAND xcrun)
@@ -57,3 +58,8 @@ list(APPEND CTEST_CUSTOM_COVERAGE_EXCLUDE
   ".*/thirdParty/.*"
   ".*/test/.*"
 )
+
+# Disable Fortran if using clang, as they do not play nicely together
+if(COMPILER MATCHES "^(clang|scan-build)$")
+  cache_append(DISABLE_FORTRAN BOOL ON)
+endif()

--- a/driver/configurations/memcheck.cmake
+++ b/driver/configurations/memcheck.cmake
@@ -59,3 +59,10 @@ else()
 endif()
 
 set(CTEST_MEMORYCHECK_TYPE "${DASHBOARD_MEMORYCHECK_TYPE}")
+
+# Disable Python (and maybe Fortran) when using Valgrind or sanitizers, as
+# they tend to make more trouble than they are worth
+cache_append(DISABLE_PYTHON BOOL ON)
+if(MEMCHECK MATCHES "^([amt]san|valgrind)$")
+  cache_append(DISABLE_FORTRAN BOOL ON)
+endif()

--- a/driver/configurations/packages.cmake
+++ b/driver/configurations/packages.cmake
@@ -84,11 +84,6 @@ else()
     disable_package(IPOPT)
   endif()
 
-  if(NOT COVERAGE AND NOT MEMCHECK MATCHES "^[amt]san$" OR NOT COMPILER MATCHES "^(clang|scan-build)$")
-    enable_package(AVL)
-    enable_package(XFOIL)
-  endif()
-
   if(NOT OPEN_SOURCE)
     if(APPLE)
       set(DASHBOARD_GUROBI_DISTRO "$ENV{HOME}/gurobi6.0.5a_mac64.pkg")
@@ -105,7 +100,9 @@ else()
   endif()
 
   if(MATLAB)
+    enable_package(AVL)
     enable_package(SPOTLESS)
+    enable_package(XFOIL)
     enable_package(YALMIP)
 
     if(APPLE)


### PR DESCRIPTION
Modify analysis tools to possible tell the build to disable Python and/or Fortran. Simplify package selection in light of these changes (disabling Fortran will also disable AVL and XFoil).

Needs comments in the code... suggestions appreciated!