### PR TITLE
Don't disable Fortran with valgrind

### DIFF
--- a/driver/configurations/generic.cmake
+++ b/driver/configurations/generic.cmake
@@ -21,7 +21,7 @@ endif()
 include(${DASHBOARD_DRIVER_DIR}/configurations/packages.cmake)
 include(${DASHBOARD_DRIVER_DIR}/configurations/timeout.cmake)
 
-if(NOT MINIMAL AND NOT OPEN_SOURCE AND NOT COMPILER STREQUAL "cpplint")
+if(NOT MINIMAL AND NOT OPEN_SOURCE)
   include(${DASHBOARD_DRIVER_DIR}/configurations/aws.cmake)
 endif()
 

--- a/driver/configurations/memcheck.cmake
+++ b/driver/configurations/memcheck.cmake
@@ -63,6 +63,6 @@ set(CTEST_MEMORYCHECK_TYPE "${DASHBOARD_MEMORYCHECK_TYPE}")
 # Disable Python (and maybe Fortran) when using Valgrind or sanitizers, as
 # they tend to make more trouble than they are worth
 cache_append(DISABLE_PYTHON BOOL ON)
-if(MEMCHECK MATCHES "^([amt]san|valgrind)$")
+if(MEMCHECK MATCHES "^[amt]san$")
   cache_append(DISABLE_FORTRAN BOOL ON)
 endif()


### PR DESCRIPTION
Fix test that inadvertently disabled Fortran when `ENV{memcheck}=valgrind`. Remove superfluous test for `ENV{compiler}=cpplint`.