### PR TITLE
Nuke JAVA_HOME in bazel builds

### DIFF
--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -1,8 +1,6 @@
 # Jenkins passes down the value of JAVA_HOME from master to slave for
 # inexplicable reasons.
-if(DASHBOARD_UNIX_DISTRIBUTION STREQUAL "Ubuntu" AND DASHBOARD_UNIX_DISTRIBUTION_VERSION VERSION_EQUAL "16.04")
-  set(ENV{JAVA_HOME} "/usr/lib/jvm/java-8-openjdk-amd64")
-endif()
+unset(ENV{JAVA_HOME})
 
 find_program(DASHBOARD_BAZEL_COMMAND bazel)
 if(NOT DASHBOARD_BAZEL_COMMAND)


### PR DESCRIPTION
At least my machines don't seem to have `JAVA_HOME` set, suggesting that Java (at least, the system-provided version) ought to work without it. Rather than fiddling with platform-specific values, just nuke it entirely, unconditionally. (This also avoids that the condition was using the wrong names for the distribution variables.)