### PR TITLE
Add git wrapper

### DIFF
--- a/driver/configurations/common/step-report-status.cmake
+++ b/driver/configurations/common/step-report-status.cmake
@@ -1,3 +1,9 @@
+# Check for git errors
+# TODO: Remove when no longer trying to track down underlying cause
+if(EXISTS "${DASHBOARD_WORKSPACE}/GIT_ERROR")
+  append_step_status("GIT" UNSTABLE)
+endif()
+
 # Determine build result and (possibly) set status message
 if(DASHBOARD_FAILURE)
   report_status(FAILURE "FAILURE DURING %STEPS%")

--- a/driver/platform/unix.cmake
+++ b/driver/platform/unix.cmake
@@ -17,6 +17,9 @@ if(ROS AND EXISTS "/opt/ros/indigo/setup.bash")
   prepend_path(CMAKE_PREFIX_PATH /opt/ros/indigo)
 endif()
 
+# Override git executable
+cache_append(GIT_EXECUTABLE PATH "${DASHBOARD_TOOLS_DIR}/git-wrapper.bash")
+
 # Set (non-Apple) paths for MATLAB
 if(MATLAB AND NOT APPLE)
   prepend_path(PATH /usr/local/MATLAB/R2015b/bin)

--- a/tools/git-wrapper.bash
+++ b/tools/git-wrapper.bash
@@ -10,4 +10,8 @@ tries=${GIT_RETRIES:-5}
 
 for (( i = 0; i < tries; ++i )); do
   $trace git "$@" && break
+  result=$?
+  touch "$WORKSPACE/GIT_ERROR"
 done
+
+exit $result

--- a/tools/git-wrapper.bash
+++ b/tools/git-wrapper.bash
@@ -12,6 +12,7 @@ for (( i = 0; i < tries; ++i )); do
   $trace git "$@" && break
   result=$?
   touch "$WORKSPACE/GIT_ERROR"
+  sleep $(( 2 ** i ))
 done
 
 exit $result

--- a/tools/git-wrapper.bash
+++ b/tools/git-wrapper.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# NOTE: Dump a whole bunch of trace diagnostics in an attempt to figure out why
+# git sometimes cannot lock the submodule config file.
+# See https://github.com/RobotLocomotion/drake/issues/4034
+trace=
+[ $(type -t strace) = 'file' ] && trace='strace -f -e trace=file'
+
+tries=${GIT_RETRIES:-5}
+
+for (( i = 0; i < tries; ++i )); do
+  $trace git "$@" && break
+done


### PR DESCRIPTION
Create a simple wrapper script to retry git operations, and to dump debugging information. Inject this as the `GIT_EXEUTABLE` for the superbuild.