### PR TITLE
Suppress git trace unless an error occurs

### DIFF
--- a/driver/configurations/common/step-report-status.cmake
+++ b/driver/configurations/common/step-report-status.cmake
@@ -2,6 +2,9 @@
 # TODO: Remove when no longer trying to track down underlying cause
 if(EXISTS "${DASHBOARD_WORKSPACE}/GIT_ERROR")
   append_step_status("GIT" UNSTABLE)
+  execute_process(
+    COMMAND /usr/bin/bash -c "ls .git-* | xargs head -n -0"
+    WORKING_DIRECTORY "${DASHBOARD_WORKSPACE}")
 endif()
 
 # Determine build result and (possibly) set status message

--- a/tools/git-wrapper.bash
+++ b/tools/git-wrapper.bash
@@ -4,12 +4,16 @@
 # git sometimes cannot lock the submodule config file.
 # See https://github.com/RobotLocomotion/drake/issues/4034
 trace=
-[ $(type -t strace) = 'file' ] && trace='strace -f -e trace=file'
+if [ $(type -t strace) = 'file' ]; then
+  log=".git-$(date -u +%F-%T.%N)-$$"
+  trace="strace -f -e trace=file"
+  echo "git $@" > $log.cmd
+fi
 
 tries=${GIT_RETRIES:-5}
 
 for (( i = 0; i < tries; ++i )); do
-  $trace git "$@" && break
+  ${trace:+$trace -o $log.trace.$i} git "$@" && break
   result=$?
   touch "$WORKSPACE/GIT_ERROR"
   sleep $(( 2 ** i ))


### PR DESCRIPTION
Modify how we trace git invocations to write logs to files rather than stderr, and to dump the logs in case of an error. This will get rid of the (very verbose) output when everything is working correctly.