### PR TITLE
Create `setup_local.sh` script

### DIFF
--- a/setup_local.bash
+++ b/setup_local.bash
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+ci="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$0")")"
+drake=~/workspace/repo/drake
+
+mkdir -p ~/workspace/repo
+
+git clone https://github.com/robotlocomotion/drake $drake
+
+for compiler in gcc clang; do
+  workspace=~/workspace/unix-$compiler-experimental
+  mkdir -p $workspace/src
+  ln -s $ci $workspace/ci
+  ln -s $drake $workspace/src/drake
+done


### PR DESCRIPTION
Create a utility script to check out drake and set up the default directories for running local CI builds. This greatly simplifies the setup steps otherwise necessary to do CI testing on a clean AWS instance.