### PR TITLE
Fix git-wrapper exit code

### DIFF
--- a/tools/git-wrapper.bash
+++ b/tools/git-wrapper.bash
@@ -13,7 +13,7 @@ fi
 tries=${GIT_RETRIES:-5}
 
 for (( i = 0; i < tries; ++i )); do
-  ${trace:+$trace -o $log.trace.$i} git "$@" && break
+  ${trace:+$trace -o $log.trace.$i} git "$@" && exit 0
   result=$?
   touch "$WORKSPACE/GIT_ERROR"
   sleep $(( 2 ** i ))


### PR DESCRIPTION
Fix a bug in the git wrapper that would cause it to fail even after succeeding on retry. The original intent was to preserve the last exit code if we ran out of retries, but the way the logic was structured was causing us to exit with the most recent failure even if a retry succeeded, because on success we would quit the loop but still return the recorded exit code from a failed attempt. Instead, when an attempt succeeds, immediately exit with a success exit code.