### PR TITLE
Temporarily disable parallel tests

### DIFF
--- a/driver/configurations/generic/step-post-drake.cmake
+++ b/driver/configurations/generic/step-post-drake.cmake
@@ -32,6 +32,7 @@ if(DASHBOARD_TEST)
     # TODO: Work out why RETURN_VALUE and RETURN_VALUE are returning
     # different values.
     ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" ${CTEST_TEST_ARGS}
+      PARALLEL_LEVEL 1
       RETURN_VALUE DASHBOARD_SUPERBUILD_TEST_RETURN_VALUE QUIET)
   endif()
 endif()


### PR DESCRIPTION
Disable parallel test execution for non-Drake tests. This is a stop-gap to work around Director's tests failing when run massively in parallel due to `xvfb-run` failing under those conditions. (A proper fix, which is to force director's tests to run serially, will be made later, when we are under less time pressure.)