### PR TITLE
Temporarily disable parallel tests

### DIFF
--- a/driver/configurations/generic/step-post-drake.cmake
+++ b/driver/configurations/generic/step-post-drake.cmake
@@ -31,7 +31,7 @@ if(DASHBOARD_TEST)
   else()
     # TODO: Work out why RETURN_VALUE and RETURN_VALUE are returning
     # different values.
-    ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" ${CTEST_TEST_ARGS}
+    ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}"
       RETURN_VALUE DASHBOARD_SUPERBUILD_TEST_RETURN_VALUE QUIET)
   endif()
 endif()


### PR DESCRIPTION
Disable parallel test execution for non-Drake tests. This is a stop-gap to work around Director's tests failing when run massively in parallel due to xvfb-run failing under those conditions. (A proper fix, which is to force director's tests to run serially, will be made later, when we are under less time pressure.)