### PR TITLE
"Fix" CTest warnings

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -37,6 +37,10 @@ set(DASHBOARD_TEMPORARY_FILES "")
 include(${DASHBOARD_DRIVER_DIR}/functions.cmake)
 include(${DASHBOARD_DRIVER_DIR}/environment.cmake)
 
+# Due to the extent to which we are modularized, CTest needs a little "hint"
+# that we are not a "declarative" CTest script
+set(CTEST_RUN_CURRENT_SCRIPT FALSE)
+
 # Set initial configuration
 set(CTEST_TEST_ARGS "")
 


### PR DESCRIPTION
At some point, CTest started complaining about unset variables when it exits. This is because the degree of modularization interferes with the logic that CTest uses to detect an old-style "declarative" script (which we are not). Avoid this by explicitly setting the variable that CTest uses to identify "declarative" scripts.