### PR TITLE
Update doc targets to use non-deprecated names

### DIFF
--- a/tools/build_documentation.bash
+++ b/tools/build_documentation.bash
@@ -2,8 +2,8 @@
 set -euxo pipefail
 export PATH="/usr/local/bin:$PATH"
 mkdir -p build/install/share/doc/drake
-unzip bazel-genfiles/drake/doc/sphinx.zip -d build/install/share/doc/drake
-./drake/doc/doxygen.py
+unzip bazel-genfiles/doc/sphinx.zip -d build/install/share/doc/drake
+./doc/doxygen.py
 cp -r build/drake/doc/doxygen_cxx/html build/install/share/doc/drake/doxygen_cxx
 echo drake.mit.edu > build/install/share/doc/drake/CNAME
 touch build/install/share/doc/drake/.nojekyll


### PR DESCRIPTION
This updates CI to use the new paths provided by RobotLocomotion/drake#7273.
