### PR TITLE
Reporting the job status and CDash link should happen very last

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -109,6 +109,9 @@ set(DASHBOARD_CDASH_URL_MESSAGES "")
 set(ENV{CMAKE_CONFIG_TYPE} "${DASHBOARD_CONFIGURATION_TYPE}")
 set(CTEST_CONFIGURATION_TYPE "${DASHBOARD_CONFIGURATION_TYPE}")
 
+# Report disk usage before build
+execute_step(common report-disk-usage)
+
 # Invoke the appropriate build driver for the selected configuration
 if(GENERATOR STREQUAL "bazel")
   include(${DASHBOARD_DRIVER_DIR}/configurations/bazel.cmake)
@@ -117,6 +120,9 @@ elseif(GENERATOR STREQUAL "cmake")
 else()
   fatal("generator is invalid")
 endif()
+
+# Report disk usage after build
+execute_step(common report-disk-usage)
 
 # Remove any temporary files that we created
 foreach(_file ${DASHBOARD_TEMPORARY_FILES})
@@ -128,3 +134,6 @@ if(DASHBOARD_FAILURE)
   message(FATAL_ERROR
     "*** Return value set to NON-ZERO due to failure during build")
 endif()
+
+# Finally, report dashboard status
+execute_step(common report-status)

--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -251,9 +251,6 @@ report_configuration("
   ====================================
   ")
 
-# Report disk usage
-execute_step(common report-disk-usage)
-
 # Run the build
 execute_step(bazel build)
 
@@ -270,8 +267,6 @@ if(DOCUMENTATION)
   endif()
 endif()
 
-# Report disk usage
-execute_step(common report-disk-usage)
+# Report Bazel command without CI-specific options
+execute_step(bazel report-bazel-command)
 
-# Report dashboard status
-execute_step(common report-status)

--- a/driver/configurations/bazel/step-report-bazel-command.cmake
+++ b/driver/configurations/bazel/step-report-bazel-command.cmake
@@ -1,8 +1,8 @@
 # -*- mode: cmake -*-
 # vi: set ft=cmake :
 
-# Copyright (c) 2016, Massachusetts Institute of Technology.
-# Copyright (c) 2016, Toyota Research Institute.
+# Copyright (c) 2019, Massachusetts Institute of Technology.
+# Copyright (c) 2019, Toyota Research Institute.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,19 +31,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Determine build result and (possibly) set status message
-if(DASHBOARD_FAILURE)
-  report_status(FAILURE "FAILURE DURING %STEPS%")
-else()
-  if(DASHBOARD_UNSTABLE)
-    report_status(UNSTABLE "UNSTABLE DUE TO %STEPS% FAILURES")
-  else()
-    file(WRITE "${DASHBOARD_WORKSPACE}/RESULT" "SUCCESS")
-  endif()
-endif()
-
-# Report build result and CDash links
-notice(
-  "CTest Result: ${DASHBOARD_MESSAGE}"
-  ${DASHBOARD_CDASH_URL_MESSAGES}
-)
+set(local_build_command
+  "${DASHBOARD_BAZEL_COMMAND} test ${DASHBOARD_BAZEL_BUILD_OPTIONS} ${DASHBOARD_BAZEL_TEST_OPTIONS} ...")
+notice("Bazel Command: ${local_build_command}")

--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -139,9 +139,6 @@ report_configuration("
   ====================================
   ")
 
-# Report disk usage
-execute_step(common report-disk-usage)
-
 execute_step(cmake build)
 
 if(NOT DASHBOARD_FAILURE)
@@ -156,7 +153,3 @@ if(NOT DASHBOARD_FAILURE)
   endif()
 endif()
 
-# Report disk usage
-execute_step(common report-disk-usage)
-
-execute_step(common report-status)


### PR DESCRIPTION
Also:
* Only report Bazel command for Bazel builds
* Move common calls (disk usage and status reporting) up one level