### PR TITLE
Fix error in run_local.bash

### DIFF
--- a/run_local.bash
+++ b/run_local.bash
@@ -31,12 +31,17 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+canonicalize()
+{
+    perl -e 'use Cwd;print Cwd::abs_path(shift) . "\n";' -- "$@"
+}
+
 set -euxo pipefail
 
-export WORKSPACE="$(pwd)"
+export WORKSPACE="$(canonicalize "$(dirname "${BASH_SOURCE}")")"
 
 export BUILD_ID="$(date -u +'%y%j.%H.%M')"
-export GIT_COMMIT="$(git --git-dir=${WORKSPACE}/src rev-parse HEAD)"
+export GIT_COMMIT="$(git --git-dir=${WORKSPACE}/src/.git rev-parse HEAD)"
 export JOB_NAME="linux-bionic-gcc-bazel-experimental-release"
 export NODE_NAME="$(hostname -s)"
 


### PR DESCRIPTION
Change how we invoke git to determine what SHA of Drake we are building to correctly specify the git directory; `git` wants the path to the `.git` directory, not the checkout. Also, tweak the script to find its own location and use that as the workspace root, rather than the current directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/127)
<!-- Reviewable:end -->
