### PR TITLE
Update location of build-wheels script

### DIFF
--- a/driver/configurations/wheel.cmake
+++ b/driver/configurations/wheel.cmake
@@ -124,7 +124,7 @@ else()
 endif()
 
 set(BUILD_ARGS
-  "${DASHBOARD_SOURCE_DIRECTORY}/tools/wheel/dev/build-wheels"
+  "${DASHBOARD_SOURCE_DIRECTORY}/tools/wheel/build-wheels"
   -t -o "${DASHBOARD_WHEEL_OUTPUT_DIRECTORY}" "${DASHBOARD_DRAKE_VERSION}")
 
 # Prepare build host


### PR DESCRIPTION
Change the driver script for wheel builds to account for the scripts in the repository moving.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/132)
<!-- Reviewable:end -->
