### PR TITLE
add experimental_repository_downloader_retries

### DIFF
--- a/tools/user.bazelrc.in
+++ b/tools/user.bazelrc.in
@@ -44,6 +44,7 @@ build --keep_going=yes
 build --subcommands=@DASHBOARD_SUBCOMMANDS@
 build --test_env=GRB_LICENSE_FILE
 build --test_env=MOSEKLM_LICENSE_FILE
+build --experimental_repository_downloader_retries=5
 
 fetch --announce_rc=yes
 fetch --build_event_json_file=@DASHBOARD_BUILD_EVENT_JSON_FILE@


### PR DESCRIPTION
Allow bazel to attempt retries for failed downloads, especially
for remotejdk on linux.

Relates: https://github.com/RobotLocomotion/drake/issues/15740

Going to spawn some test jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/142)
<!-- Reviewable:end -->
