### PR TITLE
Remove support for Bionic

### DIFF
--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -74,7 +74,7 @@ endif()
 if(APPLE)
   set(DISTRIBUTION_REGEX "(big-sur|monterey)")
 else()
-  set(DISTRIBUTION_REGEX "(bionic|focal)")
+  set(DISTRIBUTION_REGEX "(focal)")
 endif()
 string(REGEX MATCH "${DISTRIBUTION_REGEX}"
   REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")

--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -89,15 +89,10 @@ EOF
 
 systemctl --now --quiet enable /lib/systemd/system/xvfb.service
 
-if [[ "$(lsb_release -cs)" == 'bionic' ]]; then
-  apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
-    ntp
-else
-  apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
-    systemd-timesyncd
+apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
+  systemd-timesyncd
 
-  timedatectl set-ntp on
-fi
+timedatectl set-ntp on
 
 export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 


### PR DESCRIPTION
Now that #145 is landed, we can (after spinning down the Bionic builds) finish removing Bionic support.

I don't think there's any great rush on this yet, but I had the changes ready.