### PR TITLE
Add mac m1 support.

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -35,7 +35,15 @@ set -euxo pipefail
 
 [[ -z "${TERM}" ]] || export CLICOLOR_FORCE=1
 
-export PATH="/usr/local/bin:${PATH}"
+# On m1 mac, detect if we can re-run the script under arm64, since Jenkins'
+# login initially runs in an emulated x86_64 (Rosetta 2) environment.
+if [[ "$(uname -s)" == Darwin && "$(uname -p)" != "arm" ]]; then
+    if arch -arch arm64 true &>/dev/null; then
+        exec arch -arch arm64 "$0" "$@"
+    fi
+fi
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
 
 [[ ! "${JOB_NAME}" =~ unprovisioned || "$(uname -s)" != Darwin ]] || "${BASH_SOURCE%/*}/setup/mac/install_prereqs"
 [[ ! "${JOB_NAME}" =~ unprovisioned || "$(uname -s)" != Linux ]] || sudo --preserve-env "${BASH_SOURCE%/*}/setup/ubuntu/install_prereqs"

--- a/driver/platform/apple.cmake
+++ b/driver/platform/apple.cmake
@@ -33,9 +33,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 prepend_path(PATH
+  /opt/homebrew/bin
   /usr/local/bin
   /usr/bin
   /bin
+  /opt/homebrew/sbin
   /usr/local/sbin
   /usr/sbin
   /sbin)


### PR DESCRIPTION
> :warning: :skull: :warning: :skull_and_crossbones: :warning: :skull: :warning:
> If you are reading this, **please** do **NOT** run either of the bot commands on your PR!!!
>
> - `@drake-jenkins-bot mac-m1-monterey-clang-bazel-experimental-release please.`
> - `@drake-jenkins-bot mac-m1-monterey-unprovisioned-clang-bazel-experimental-release please.`
>
> The cluster is using an intentionally precarious setup due to behind the scenes limitations, if you run either of those jobs you will make testing for me incur >30 minute wait times.  Thank you.
> :warning: :skull: :warning: :skull_and_crossbones: :warning: :skull: :warning:

Test builds associated with these changes have a manual change to checkout the `drake-ci` branch `feat/mac-m1-support` rather than `main`.

To verify that the changes in this PR don't break the x86_64 builds:

- [X] Monterey x86_64 job: https://drake-jenkins.csail.mit.edu/view/Mac%20Monterey/job/mac-monterey-clang-bazel-experimental-release/39/
    ```
    [3:38:49 PM]  ++ uname -s
    [3:38:49 PM]  + [[ Darwin == Darwin ]]
    [3:38:49 PM]  ++ uname -p
    [3:38:49 PM]  + [[ i386 != \a\r\m ]]
    [3:38:49 PM]  + arch -arch arm64 true
    [3:38:49 PM]  + export PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
    [3:38:49 PM]  + PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
    ```

    Cancelled job to spare mac-ci, the above indicates success (no `exec` statement on x86_64).
- [X] Big Sur x86_64 job: https://drake-jenkins.csail.mit.edu/view/Mac%20Big%20Sur/job/mac-big-sur-clang-bazel-experimental-everything-release/37/
    ```
    [3:37:28 PM]  ++ uname -s
    [3:37:28 PM]  + [[ Darwin == Darwin ]]
    [3:37:28 PM]  ++ uname -p
    [3:37:28 PM]  + [[ i386 != \a\r\m ]]
    [3:37:28 PM]  + arch -arch arm64 true
    [3:37:28 PM]  + export PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
    [3:37:28 PM]  + PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
    ```

    Cancelled job to spare mac-ci, the above indicates success (no `exec` statement on x86_64).
- [X] Focal x86_64 job: https://drake-jenkins.csail.mit.edu/view/Linux%20Focal/job/linux-focal-clang-bazel-experimental-everything-release/242/

M1 builds:

- [X] M1 provisioned: https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-clang-bazel-experimental-release/8/
    ```
    [3:12:49 PM]  In file included from bazel-out/darwin_arm64-opt/bin/external/ibex/filibsrc-3.0.2.2/fp_traits/fp_traits.hpp:295:
    [3:12:49 PM]  bazel-out/darwin_arm64-opt/bin/external/ibex/filibsrc-3.0.2.2/fp_traits/fp_traits_sse_const.hpp:75:21: error: couldn't allocate output register for constraint 'x'
    [3:12:49 PM]                                                  asm volatile ("ldmxcsr %2\n" "addsd %1, %0\n" : "+x" (a) : "x" (b), "m" (sseConstants::mxcsr_down) );
    ```

   This failure indicates success!
- [ ] M1 unprovisioned: unprovisioned images are needing to be rebuilt, orthogonal to this PR.  Need to find a way to remove the password otherwise `brew install --cask adoptopenjdk` and a couple others fail needing `sudo` password.

NOTE: the above jobs are not expected to succeed, the build will fail on IBEX x86_64 intrinsics (which indicates it successfully compiled as `arm64`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/148)
<!-- Reviewable:end -->
