### PR TITLE
Use `--config=` for consistency

### DIFF
--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -117,7 +117,7 @@ if(REMOTE_CACHE)
   )
 endif()
 
-set(DASHBOARD_BAZEL_BUILD_OPTIONS "--config ${COMPILER} --compilation_mode")
+set(DASHBOARD_BAZEL_BUILD_OPTIONS "--config=${COMPILER} --compilation_mode")
 
 if(DEBUG)
   set(DASHBOARD_BAZEL_BUILD_OPTIONS "${DASHBOARD_BAZEL_BUILD_OPTIONS}=dbg")


### PR DESCRIPTION
Use `--config=${COMPILER}` instead of `--config ${COMPILER}` for consistency with documentation and with other uses of `--config`. This is purely an aesthetic change; Bazel should parse the arguments the same in either case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/153)
<!-- Reviewable:end -->
