### PR TITLE
Revert "Use --config=omp when building GCC + Everything"

### DIFF
--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -134,12 +134,6 @@ set(DASHBOARD_TEST_TAG_FILTERS)
 
 if(EVERYTHING)
   set(DASHBOARD_BAZEL_BUILD_OPTIONS "${DASHBOARD_BAZEL_BUILD_OPTIONS} --config=everything")
-  # TODO(jwnimmer-tri) Once we've finished the Clang 12 upgrade and therefore
-  # can enable OpenMP on Clang, we should move `--config omp` into bazelrc as
-  # part of `--config everything`, instead of having special drake-ci logic.
-  if(COMPILER STREQUAL "gcc")
-    set(DASHBOARD_BAZEL_BUILD_OPTIONS "${DASHBOARD_BAZEL_BUILD_OPTIONS} --config=omp")
-  endif()
 elseif(GUROBI OR MOSEK OR PACKAGE OR SNOPT)
   set(DASHBOARD_TEST_TAG_FILTERS
     "-gurobi"


### PR DESCRIPTION
Reverts RobotLocomotion/drake-ci#154.  As of https://github.com/RobotLocomotion/drake/pull/17154, this is built-in to Drake now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/156)
<!-- Reviewable:end -->
