### PR TITLE
Update init_script for focal+jammy /media/ephemeral0/ubuntu

### DIFF
--- a/setup/ubuntu/init_script
+++ b/setup/ubuntu/init_script
@@ -41,7 +41,44 @@ fi
 systemctl --quiet disable apt-daily-upgrade.timer apt-daily.timer
 
 if [[ ! -d /media/ephemeral0/ubuntu ]]; then
-  readonly DEV_EPHEMERAL0="/dev/$(lsblk | grep -Eo 'nvme[01np]+' | grep -v $(lsblk | grep -Eo  'nvme[01n]+p1' | grep -Eo 'nvme[01n]'))"
+  # NOTE: each distribution upgrade has resulted in changing the search logic
+  # to find the largest disk attached to create /media/ephemeral0/ubuntu.  In
+  # this formulation we rely on `lsblk` reporting type `disk` for the desired
+  # destination drive, which may not always be true.  Example standard outputs:
+  #
+  # Focal:
+  # $ lsblk
+  # NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+  # ... loop devices ...
+  # nvme1n1     259:0    0 372.5G  0 disk
+  # nvme0n1     259:1    0    16G  0 disk
+  # └─nvme0n1p1 259:2    0    16G  0 part /
+  #
+  # Jammy:
+  # NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
+  # ... loop devices ...
+  # nvme0n1      259:0    0     8G  0 disk
+  # ├─nvme0n1p1  259:2    0   7.9G  0 part /
+  # ├─nvme0n1p14 259:3    0     4M  0 part
+  # └─nvme0n1p15 259:4    0   106M  0 part /boot/efi
+  # nvme1n1      259:1    0 372.5G  0 disk
+  #
+  # In both instances we desire `/dev/nvme1n1`, which is the largest disk
+  # storage attached.  The pipeline below executes:
+  #
+  # 1. `lsblk` to query SIZE (in bytes via -b to enable sorting), NAME, and
+  #    TYPE, output in key="value" pairs (-P) to make `sed` more reliable.
+  # 2. Filter for just the `disk` types using `grep`.
+  # 3. Transform remaining `SIZE="size" NAME="name" TYPE="type"` lines into
+  #    `size:name` using `sed` to enable sorting on `size` and easy `name`
+  #    extraction via `cut`.
+  # 4. Numerically sort in reverse the output (`sort -nr`), meaning the largest
+  #    `disk` will be the first line, and select the largest (`head -1`).
+  # 5. Finally, extract `name` from `size:name` via `cut`, producing a final
+  #    result of `/dev/{name}` to create the additional storage on.
+  readonly DEV_EPHEMERAL0="/dev/$(lsblk -b -o SIZE,NAME,TYPE -P | grep disk | \
+    sed 's/SIZE="\(.*\)" NAME="\(.*\)" TYPE=.*/\1:\2/g' | sort -nr | head -1 | \
+    cut -d : -f 2)"
 
   mkfs -t ext4 "${DEV_EPHEMERAL0}"
   mkdir -p /media/ephemeral0


### PR DESCRIPTION
Current logic using `grep` crashes on Jammy.  On focal the nested `grep -v $(lsblk | grep -Eo  'nvme[01n]+p1' | grep -Eo 'nvme[01n]'` produces one result, on Jammy it produces 3.

Replace this with new logic that will hopefully be resilient to new distribution upgrades, assuming Amazon does not modify the mounting strategies -- if `lsblk` does not report `TYPE="disk"` in the future the logic will need to be revised again.

Relates: https://github.com/RobotLocomotion/drake/issues/17185

Previous iterations included some debug printing which are included here for reference.

## Focal Node Initialization

```
+ lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
loop0         7:0    0  33.3M  1 loop /snap/amazon-ssm-agent/3552
loop1         7:1    0    25M  1 loop /snap/amazon-ssm-agent/4046
loop2         7:2    0  25.1M  1 loop /snap/amazon-ssm-agent/5656
loop4         7:4    0  73.1M  1 loop /snap/lxd/21902
loop5         7:5    0  55.5M  1 loop /snap/core18/2253
loop6         7:6    0  61.9M  1 loop /snap/core20/1242
loop7         7:7    0  68.8M  1 loop /snap/lxd/20037
loop8         7:8    0  99.4M  1 loop /snap/core/11993
loop9         7:9    0  55.5M  1 loop /snap/core18/2409
loop10        7:10   0  61.9M  1 loop /snap/core20/1434
loop11        7:11   0 110.6M  1 loop /snap/core/12834
nvme1n1     259:0    0 372.5G  0 disk 
nvme0n1     259:1    0    16G  0 disk 
└─nvme0n1p1 259:2    0    16G  0 part /

+ NEW_DEV_EPHEMERAL0=nvme1n1
+ echo 'NEW_DEV_EPHEMERAL0: nvme1n1'
...
+ readonly DEV_EPHEMERAL0=/dev/nvme1n1
+ DEV_EPHEMERAL0=/dev/nvme1n1
+ echo 'DEV_EPHEMERAL0: /dev/nvme1n1'
```

## Jammy Node Initialization

```
+ lsblk
NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0  26.6M  1 loop /snap/amazon-ssm-agent/5163
loop1          7:1    0  25.1M  1 loop /snap/amazon-ssm-agent/5656
loop2          7:2    0  55.5M  1 loop /snap/core18/2344
loop3          7:3    0  55.5M  1 loop /snap/core18/2409
loop4          7:4    0  61.9M  1 loop /snap/core20/1405
loop5          7:5    0  61.9M  1 loop /snap/core20/1434
loop6          7:6    0  79.9M  1 loop /snap/lxd/22894
loop7          7:7    0  79.9M  1 loop /snap/lxd/22923
loop8          7:8    0  43.6M  1 loop /snap/snapd/15177
loop9          7:9    0  44.7M  1 loop /snap/snapd/15534
nvme0n1      259:0    0     8G  0 disk 
├─nvme0n1p1  259:2    0   7.9G  0 part /
├─nvme0n1p14 259:3    0     4M  0 part 
└─nvme0n1p15 259:4    0   106M  0 part /boot/efi
nvme1n1      259:1    0 372.5G  0 disk 
...
+ readonly NEW_DEV_EPHEMERAL0=nvme1n1
+ NEW_DEV_EPHEMERAL0=nvme1n1
+ echo 'NEW_DEV_EPHEMERAL0: nvme1n1'
NEW_DEV_EPHEMERAL0: nvme1n1
... vvv this is what is failing
++ grep -v nvme0 nvme0 nvme0
grep: nvme0: No such file or directory
grep: nvme0: No such file or directory
+ readonly DEV_EPHEMERAL0=/dev/
+ DEV_EPHEMERAL0=/dev/
+ echo 'DEV_EPHEMERAL0: /dev/'
DEV_EPHEMERAL0: /dev/
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/158)
<!-- Reviewable:end -->
