### PR TITLE
Stop using Kitware apt CMake

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -62,6 +62,7 @@ apt-get upgrade -o Dpkg::Options::=--force-confdef \
 apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
   awscli \
   ca-certificates \
+  cmake \
   git \
   gnupg \
   lsb-release \
@@ -93,21 +94,6 @@ apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
   systemd-timesyncd
 
 timedatectl set-ntp on
-
-export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-
-wget -q -t 4 -O- --retry-connrefused \
-  https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
-
-echo "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
-  > /etc/apt/sources.list.d/kitware.list
-
-apt-get update -qq || (sleep 15; apt-get update -qq)
-apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
-  cmake \
-  kitware-archive-keyring
-
-apt-key --keyring /etc/apt/trusted.gpg del A8E5EF3A02600268
 
 wget -nv -t 4 -O /tmp/gurobi9.5.1_linux64.tar.gz --retry-connrefused \
   https://packages.gurobi.com/9.5/gurobi9.5.1_linux64.tar.gz


### PR DESCRIPTION
Previously at least CMake 3.15 was needed for CTest / CDash related items.  Now that bionic is gone, the default Ubuntu CMake will be sufficient.

Confirmatory CI jobs:

- [X] Focal unprovisioned: https://drake-jenkins.csail.mit.edu/view/Linux%20Focal%20Unprovisioned/job/linux-focal-unprovisioned-clang-bazel-experimental-everything-release/20/console
- [X] Jammy unprovisioned: https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-clang-bazel-experimental-release/3/console
- [X] Jammy unprovisioned everything: https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-gcc-bazel-experimental-everything-release/1/console

Focal everything is expected to pass, for the Jammy builds we are just looking to see that `install_prereqs` is able to complete (install `cmake` and start running the driver), we do not care whether the build succeeds or not for this PR.  But we do care that the Jenkins dashboard gets updated correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/159)
<!-- Reviewable:end -->
