### PR TITLE
Add jammy job name detection

### DIFF
--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -74,7 +74,7 @@ endif()
 if(APPLE)
   set(DISTRIBUTION_REGEX "(big-sur|monterey)")
 else()
-  set(DISTRIBUTION_REGEX "(focal)")
+  set(DISTRIBUTION_REGEX "(focal|jammy)")
 endif()
 string(REGEX MATCH "${DISTRIBUTION_REGEX}"
   REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")


### PR DESCRIPTION
See also: https://github.com/RobotLocomotion/drake/issues/17185#issuecomment-1139958828

Jobs built with this PR to test job name creation:

- [X] https://drake-jenkins.csail.mit.edu/view/Linux%20Focal/job/linux-focal-gcc-bazel-experimental-everything-release/910/console
- [X] https://drake-jenkins.csail.mit.edu/view/Linux%20Focal/job/linux-focal-clang-bazel-experimental-everything-release/933/console
- [X] https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-gcc-bazel-experimental-everything-release/2/console
- [X] https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-clang-bazel-experimental-everything-release/1/console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/160)
<!-- Reviewable:end -->
