### PR TITLE
Don't clean up macOS wheel build

### DIFF
--- a/driver/configurations/wheel.cmake
+++ b/driver/configurations/wheel.cmake
@@ -104,6 +104,12 @@ else()
 endif()
 
 if(APPLE)
+  # Don't try to clean up after the build, because the wheel gets dumped into
+  # one of the trees that "cleaning up" would try to clean up. This would
+  # result in the wheel being deleted, except that the builder can't delete it
+  # due to permissions, which would be flagged as a build error.
+  list(APPEND BUILD_ARGS -k)
+
   # Ensure the build can write to /opt and /opt/drake; the latter might have
   # been created as a parent of DASHBOARD_WHEEL_OUTPUT_DIRECTORY and needs to
   # be writable by not-root


### PR DESCRIPTION
Don't try to clean up after the macOS wheel build, because the wheel gets dumped into one of the trees that "cleaning up" would try to clean up. This would result in the wheel being deleted, except that the builder can't delete it due to permissions, which would be flagged as a build error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/162)
<!-- Reviewable:end -->
