### PR TITLE
Upload wheels to AWS S3

### DIFF
--- a/driver/configurations/wheel.cmake
+++ b/driver/configurations/wheel.cmake
@@ -123,6 +123,8 @@ else()
     execute_step(wheel build-and-test)
 endif()
 
+execute_step(wheel upload-wheel)
+
 # Determine build result
 if(NOT DASHBOARD_FAILURE AND NOT DASHBOARD_UNSTABLE)
   set(DASHBOARD_MESSAGE "SUCCESS")

--- a/driver/configurations/wheel/step-upload-wheel.cmake
+++ b/driver/configurations/wheel/step-upload-wheel.cmake
@@ -1,0 +1,47 @@
+# -*- mode: cmake; -*-
+# vi: set ft=cmake:
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Massachusetts Institute of Technology.
+# Copyright (c) 2022, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if(DASHBOARD_FAILURE OR DASHBOARD_UNSTABLE)
+  notice("CTest Status: NOT UPLOADING WHEEL BECAUSE WHEEL BUILD WAS NOT SUCCESSFUL")
+else()
+  notice("CTest Status: UPLOADING WHEEL(S)")
+  # Some builds will produce multiple wheels, and in any case the exact names
+  # can be extremely hard to predict aside from simply listing known names
+  # (which is a maintenance nightmare). So, don't even bother trying; just
+  # upload anything that's a '.whl' in the output directory.
+  file(GLOB DASHBOARD_WHEELS "${DASHBOARD_WHEEL_OUTPUT_DIRECTORY}/*.whl")
+  foreach(WHEEL IN LISTS DASHBOARD_WHEELS)
+    aws_upload("${WHEEL}" "WHEEL UPLOAD")
+  endforeach()
+endif()

--- a/driver/functions.cmake
+++ b/driver/functions.cmake
@@ -318,6 +318,7 @@ macro(aws_upload ARTIFACT UNSTABLE_MESSAGE)
   execute_process(
     COMMAND ${DASHBOARD_PYTHON_COMMAND}
       "${DASHBOARD_TOOLS_DIR}/upload-to-aws.py"
+      --bucket "drake-packages"
       --track "${DASHBOARD_TRACK}"
       --aws "${DASHBOARD_AWS_COMMAND}"
       "${ARTIFACT}"


### PR DESCRIPTION
Add a step to upload wheels to AWS S3. Modify the upload script to accept the name of a bucket to use, rather than hard-coding "drake-packages" (although we still hard-code this at the CMake level, for now). Refactor logic that computes URIs to handle special characters, which are present in experimental wheel names.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/165)
<!-- Reviewable:end -->
