### PR TITLE
Fix jammy package resolution issues with systemd versions

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -91,7 +91,7 @@ EOF
 systemctl --now --quiet enable /lib/systemd/system/xvfb.service
 
 apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
-  systemd-timesyncd
+  systemd systemd-timesyncd
 
 timedatectl set-ntp on
 


### PR DESCRIPTION
The following packages have unmet dependencies:
   systemd-timesyncd : Depends: systemd (= 249.11-0ubuntu3) but 249.11-0ubuntu3.1 is to be installed
E: Unable to correct problems, you have held broken packages.

We aren't sure if this is actually necessary long term, but opening a PR enables building against it with a separate drake PR.