### PR TITLE
Work around broken EC2 Jammy mirror

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -90,8 +90,22 @@ EOF
 
 systemctl --now --quiet enable /lib/systemd/system/xvfb.service
 
-apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
+timesyncd_packages=(
+  libsystemd0
+  systemd
   systemd-timesyncd
+)
+
+systemd_compat_version="$(
+    $WORKSPACE/ci/tools/apt-common-version.py "${timesyncd_packages[@]}"
+)"
+
+for ((i = 0; i < ${#timesyncd_packages[@]}; ++i)); do
+    timesyncd_packages[$i]="${timesyncd_packages[$i]}=$systemd_compat_version"
+done
+
+apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
+  "${timesyncd_packages[@]}"
 
 timedatectl set-ntp on
 

--- a/tools/apt-common-version.py
+++ b/tools/apt-common-version.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Massachusetts Institute of Technology.
+# Copyright (c) 2022, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import apt_pkg
+import sys
+
+def get_common_version(packages):
+    # Initialize and get apt cache
+    apt_pkg.init()
+    cache = apt_pkg.Cache()
+
+    # Get available versions of matching packages
+    versions = []
+    for p in cache.packages:
+        if p.name in packages:
+            versions.append({v.ver_str for v in p.version_list})
+
+    # Get intersection of versions
+    versions = set.intersection(*versions)
+    best = None
+    for v in versions:
+        if best is None or apt_pkg.version_compare(v, best) > 0:
+            best = v
+
+    return best
+
+
+if __name__ == '__main__':
+    v = get_common_version(set(sys.argv[1:]))
+    print(v)


### PR DESCRIPTION
Since approximately 2022-06-22, Amazon's EC2 mirror of the Jammy package repository has contained an updated `systemd` (`249.11-0ubuntu3.1`) with an out-of-date and incompatible `systemd-timesyncd` (`249.11-0ubuntu3`). This prevents the latter from being installed, which in turn prevents CI from completing its pre-build setup.

Work around this by explicitly permitting downgrades when installing `systemd-timesyncd`.

Note that, as of 2022-06-24, the current version of these packages is `249.11-0ubuntu3.3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/168)
<!-- Reviewable:end -->
