### PR TITLE
Remove support for timedatectl / timesyncd

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -58,21 +58,10 @@ fi
 # Synchronize the system clock (so log timestamps will be accurate).
 if [ -n "$(type -P chronyc)" ]; then
     # Synchronize using chrony.
-    # TODO(mwoehlke-kitware) do always when all images are using chrony
     sudo --preserve-env chronyc makestep
     chronyc tracking
-elif [ -n "$(type -P timedatectl)" ]; then
-    # Synchronize using systemd-timesyncd; there isn't an explicit command for
-    # this, but toggling synchronization and restarting the daemon should
-    # trigger an explicit synchronization.
-    # TODO(mwoehlke-kitware) remove this when all images are using chrony
-    sudo --preserve-env timedatectl set-ntp off
-    sudo --preserve-env timedatectl set-ntp on
-    sudo --preserve-env systemctl restart systemd-timesyncd
-    timedatectl status
 elif [ "$(uname)" == "Darwin" ]; then
-    : # Allow macOS to proceed without synchronization.
-    # TODO(mwoehlke-kitware) remove this when all images have chrony installed?
+    : # Allow macOS to proceed without explicit synchronization.
 else
     echo "Unable to locate NTP interface" >&2
     exit 1


### PR DESCRIPTION
Change initial time synchronization to only support `chrony`, removing support for `timedatectl` a.k.a. `timesyncd`. We can do this now, as the provisioned images have been updated to have `chrony`.

The logic to ensure that `chrony` is installed is being left as-is. On Jammy, this should be a no-op, but as of writing, the Focal unprovisioned images still have `timesyncd`, which is replaced when `chrony` is installed.

Also, drop the TODOs to use `chrony` everywhere, as, while it is available on macOS (and we may yet revisit this), setting up the daemon appears to be non-trivial. (Also, macOS presumably has its own NTP service.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/171)
<!-- Reviewable:end -->
