### PR TITLE
Fix aws upload call to max_age

### DIFF
--- a/tools/upload-to-aws.py
+++ b/tools/upload-to-aws.py
@@ -192,7 +192,7 @@ def upload_artifacts(options):
             prefix = m.group(1)
             residue = m.group(4)
             name = f'{prefix}latest-{residue}'
-            expiration = max_age(options, latest=True)
+            expiration = max_age(options)
 
             upload(path, name, options, expiration=expiration)
             upload_checksum(path, name, options, expiration=expiration)


### PR DESCRIPTION
Remnant of #157, the max_age signature changed but we overlooked updating the call-site.

Hotfix for https://drakedevelopers.slack.com/archives/C270MN28G/p1657574332375409?thread_ts=1657573010.133889&cid=C270MN28G, retesting job.