### PR TITLE
Download gurobi license during setup like mosek

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -105,9 +105,4 @@ tar -C /opt -xf /tmp/gurobi9.5.1_linux64.tar.gz
 echo '12f63795802c7b74cd0ccc87ed73061346a3a28933e6860fad9c7dbfcf5d9250  /opt/gurobi951/linux64/include/gurobi_c.h' \
   | sha256sum -c -
 
-aws s3 cp --only-show-errors s3://drake-provisioning/gurobi/gurobi.lic \
-  /opt/gurobi951/gurobi.lic
-echo '85a76935617e809af43275fa4d7f7fc38182973c5756edde9b8db59ef65420cb  /opt/gurobi951/gurobi.lic' \
-  | sha256sum -c -
-
 chown -R root:root /opt/gurobi951


### PR DESCRIPTION
Rather than have the gurobi license be baked into the provisioned images, we will download the gurobi license file in the same way that we obtain the MOSEK license.  This reduces the likelihood of bad image configurations that led to orka m1 gurobi confusion.

Job experiments with this PR:

- [X] arm64 mac: https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-provisioned-clang-bazel-experimental-everything-release/17/console
    - Failures in the job are related to MOSEK tests needing to be disabled on m1 https://github.com/RobotLocomotion/drake/pull/17269#pullrequestreview-986692296
- [X] x86_64 mac: https://drake-jenkins.csail.mit.edu/view/Mac%20Big%20Sur/job/mac-big-sur-clang-cmake-experimental-everything-release/lastBuild/console
- [X] focal: https://drake-jenkins.csail.mit.edu/view/Linux%20Focal/job/linux-focal-gcc-bazel-experimental-everything-release/2037/console
- [X] focal unprovisioned: https://drake-jenkins.csail.mit.edu/view/Linux%20Focal%20Unprovisioned/job/linux-focal-unprovisioned-gcc-bazel-experimental-everything-release/10/console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/177)
<!-- Reviewable:end -->
