### PR TITLE
Fix aws cache max entry being too short for nightly

### DIFF
--- a/tools/upload-to-aws.py
+++ b/tools/upload-to-aws.py
@@ -87,9 +87,11 @@ def max_age(options):
     def to_seconds(**kwargs):
         return int(datetime.timedelta(**kwargs).total_seconds())
 
-    if options.nightly:
-        return to_seconds(hours=18)
-    elif options.continuous:
+    # NOTE: we need nightly artifacts specifically to expire fairly quickly,
+    # otherwise drake-external-examples may receive a cached version from
+    # Amazon CloudFront (default is 24 hours when not specified):
+    # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
+    if options.nightly or options.continuous:
         return to_seconds(minutes=30)
 
     raise ValueError(


### PR DESCRIPTION
Drake external examples CI was downloading a cached version.

See [slack discussion](https://drakedevelopers.slack.com/archives/C270MN28G/p1664907864917359) where this was found.

Prior to testing a job with this change:

```console
curl -sSL -D - https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz -o /dev/null
HTTP/2 200 
content-type: application/x-tar
content-length: 242876304
date: Tue, 04 Oct 2022 19:16:59 GMT
last-modified: Tue, 04 Oct 2022 08:32:18 GMT
...
cache-control: max-age=64800
...

^C
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/183)
<!-- Reviewable:end -->
