### PR TITLE
Print out C / C++ compiler and version

### DIFF
--- a/driver/compiler.cmake
+++ b/driver/compiler.cmake
@@ -69,3 +69,7 @@ if("${DASHBOARD_CXX_COMMAND}" STREQUAL "")
 endif()
 
 string(TOUPPER "${COMPILER}" COMPILER_UPPER)
+
+# Extract the compiler version strings for logging purposes.
+compiler_version_string("${DASHBOARD_CC_COMMAND}" DASHBOARD_CC_VERSION_STRING)
+compiler_version_string("${DASHBOARD_CXX_COMMAND}" DASHBOARD_CXX_VERSION_STRING)

--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -256,6 +256,11 @@ report_configuration("
   SNOPT_PATH
   TERM
   ==================================== >DASHBOARD_
+  CC_COMMAND
+  CC_VERSION_STRING
+  CXX_COMMAND
+  CXX_VERSION_STRING
+  ==================================== >DASHBOARD_
   UNIX
   UNIX_DISTRIBUTION
   UNIX_DISTRIBUTION_CODE_NAME

--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -140,6 +140,11 @@ report_configuration("
   SNOPT_PATH
   TERM
   ==================================== >DASHBOARD_
+  CC_COMMAND
+  CC_VERSION_STRING
+  CXX_COMMAND
+  CXX_VERSION_STRING
+  ==================================== >DASHBOARD_
   UNIX
   UNIX_DISTRIBUTION
   UNIX_DISTRIBUTION_CODE_NAME

--- a/driver/configurations/common/step-report-configuration.cmake
+++ b/driver/configurations/common/step-report-configuration.cmake
@@ -37,6 +37,11 @@ report_configuration(".38
   CC
   CXX
   ==================================== >DASHBOARD_
+  CC_COMMAND
+  CC_VERSION_STRING
+  CXX_COMMAND
+  CXX_VERSION_STRING
+  ==================================== >DASHBOARD_
   UNIX
   UNIX_DISTRIBUTION
   UNIX_DISTRIBUTION_CODE_NAME

--- a/driver/configurations/wheel.cmake
+++ b/driver/configurations/wheel.cmake
@@ -85,6 +85,11 @@ endif()
 
 # Report build configuration
 report_configuration("
+  ==================================== >DASHBOARD_
+  CC_COMMAND
+  CC_VERSION_STRING
+  CXX_COMMAND
+  CXX_VERSION_STRING
   ====================================
   CMAKE_VERSION
   ====================================

--- a/driver/functions.cmake
+++ b/driver/functions.cmake
@@ -384,3 +384,28 @@ endfunction()
 macro(execute_step CONFIG NAME)
   include(${DASHBOARD_DRIVER_DIR}/configurations/${CONFIG}/step-${NAME}.cmake)
 endmacro()
+
+#------------------------------------------------------------------------------
+# Execute `${COMPILER} --version` and store the first line of the result in
+# `OUTPUT_VARIABLE`.  This function is used in compiler.cmake only to be able
+# to log the compiler version in Jenkins, we do not care about detecting exact
+# major / minor / patch versions of a given compiler.
+#------------------------------------------------------------------------------
+function(compiler_version_string COMPILER OUTPUT_VARIABLE)
+  if(NOT ARGC EQUAL 2)
+    fatal("Usage: compiler_version_string(\${COMPILER} OUTPUT_VARIABLE)")
+  endif()
+  # Execute `${COMPILER} --version`
+  execute_process(COMMAND "${COMPILER}" "--version"
+    OUTPUT_VARIABLE compiler_version
+    ERROR_VARIABLE compiler_error
+    RESULT_VARIABLE compiler_result_variable)
+  if(compiler_result_variable)
+    fatal("unable to determine '${compiler} --version': ${compiler_error}")
+  endif()
+  # Extract the first line and set the output.
+  string(REGEX REPLACE ";" "\\\\;" compiler_version "${compiler_version}")
+  string(REGEX REPLACE "\n" ";" compiler_version "${compiler_version}")
+  list(GET compiler_version 0 compiler_version)
+  set(${OUTPUT_VARIABLE} "${compiler_version}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
There currently is no logging information stating compiler versions.

- [X] [mac arm64 // clang // bazel](https://drake-jenkins.csail.mit.edu/view/Mac%20M1/job/mac-m1-monterey-provisioned-clang-bazel-experimental-everything-debug/11/console)
    ```
    [4:20:14 PM]    CC_COMMAND                     = /usr/bin/clang
    [4:20:14 PM]    CC_VERSION_STRING              = Apple clang version 14.0.0 (clang-1400.0.29.102)
    [4:20:14 PM]    CXX_COMMAND                    = /usr/bin/clang++
    [4:20:14 PM]    CXX_VERSION_STRING             = Apple clang version 14.0.0 (clang-1400.0.29.102)
    ```
- [X] [mac x86_64 // clang // cmake](https://drake-jenkins.csail.mit.edu/view/Mac%20Monterey/job/mac-monterey-clang-cmake-experimental-debug/2/console)
    ```
    [4:22:20 PM]    CC_COMMAND                     = /usr/bin/clang
    [4:22:20 PM]    CC_VERSION_STRING              = Apple clang version 14.0.0 (clang-1400.0.29.102)
    [4:22:20 PM]    CXX_COMMAND                    = /usr/bin/clang++
    [4:22:20 PM]    CXX_VERSION_STRING             = Apple clang version 14.0.0 (clang-1400.0.29.102)
    ```
- [X] [focal // gcc // wheel](https://drake-jenkins.csail.mit.edu/view/Wheel/job/linux-focal-unprovisioned-gcc-wheel-experimental-snopt-mosek-release/74/console)
    ```
    [4:28:35 PM]    CC_COMMAND                     = /usr/bin/gcc
    [4:28:35 PM]    CC_VERSION_STRING              = gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
    [4:28:35 PM]    CXX_COMMAND                    = /usr/bin/g++
    [4:28:35 PM]    CXX_VERSION_STRING             = g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
    ```
- [X] [jammy // gcc // bazel](https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy/job/linux-jammy-gcc-bazel-experimental-everything-debug/5/console)
    ```
    [4:24:48 PM]    CC_COMMAND                     = /usr/bin/gcc
    [4:24:48 PM]    CC_VERSION_STRING              = gcc (Ubuntu 11.2.0-19ubuntu1) 11.2.0
    [4:24:48 PM]    CXX_COMMAND                    = /usr/bin/g++
    [4:24:48 PM]    CXX_VERSION_STRING             = g++ (Ubuntu 11.2.0-19ubuntu1) 11.2.0
    ```
- [X] NOTE: AFAICT the file `step-report-configuration.cmake` is no longer used anywhere... (`grep -ri execute_step . | grep -i report` shows `report-disk-usage`, `report-status`, `report-bazel-command`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ci/184)
<!-- Reviewable:end -->
