### PR TITLE
[setup] Install docker buildx plugin

### DIFF
--- a/setup/docker/install_prereqs
+++ b/setup/docker/install_prereqs
@@ -63,4 +63,4 @@ echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -c
 apt-get update -o APT::Acquire::Retries=4 -qq \
   || (sleep 15; apt-get update -o APT::Acquire::Retries=4 -qq)
 apt-get install --no-install-recommends -o APT::Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy \
-  docker-ce
+  docker-ce docker-buildx-plugin


### PR DESCRIPTION
The wheel build started failling due to an update in the docker command line interface:

https://github.com/docker/cli/blob/master/docs/deprecated.md#legacy-builder-for-linux-images

As of docker 23.0+ (recently released) we need to install the corresponding buildx plugin in order to use DOCKER_BUILDKIT=1 in the wheel builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/197)
<!-- Reviewable:end -->
