### PR TITLE
Revert "Run Gurobi tests in parallel"

### DIFF
--- a/driver/configurations/gurobi.cmake
+++ b/driver/configurations/gurobi.cmake
@@ -61,6 +61,3 @@ endif()
 
 # Always set environment variable so remote caches may be shared.
 set(ENV{GRB_LICENSE_FILE} "${GRB_LICENSE_FILE}")
-
-# Run Gurobi tests in parallel in the CI
-set(ENV{DRAKE_GUROBI_LICENSE_UNLIMITED} 1)


### PR DESCRIPTION
Reverts RobotLocomotion/drake-ci#194

This change is causing CI timeouts, see [slack thread](https://drakedevelopers.slack.com/archives/C270MN28G/p1676301017489389) and [drake #18775](https://github.com/RobotLocomotion/drake/issues/18775) for details

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/199)
<!-- Reviewable:end -->
