### PR TITLE
[cache] Temporarily disable mac-arm64 cache

### DIFF
--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -166,19 +166,21 @@ if(REGEX_MATCH_RESULT)
   set(REMOTE_CACHE ON)
 endif()
 
+# TODO(svenevs): on 2023-02-16 we are undergoing a cache server migration on the
+# backend and need to disable it until the transition is complete.
 # TODO(svenevs): sort through the logic above and enable more (debug).
 # This expression is a temporary kludge to test out the cache with mac-arm using
 # the same jobs that mac-x86 is currently caching.
 string(REGEX MATCH "(mac-arm-monterey-clang-bazel-continuous-release|mac-arm-monterey-clang-bazel-experimental-everything-release|mac-arm-monterey-clang-bazel-experimental-release|mac-arm-monterey-clang-bazel-nightly-everything-release|mac-arm-monterey-clang-cmake-experimental-everything-release|mac-arm-monterey-clang-cmake-experimental-release|mac-arm-monterey-clang-cmake-nightly-everything-release|mac-arm-monterey-clang-cmake-nightly-release)" REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")
 if(REGEX_MATCH_RESULT)
-  set(REMOTE_CACHE ON)
+  set(REMOTE_CACHE OFF)
 endif()
 
 # We are also testing out running debug jobs with the new cache server.  There
 # is currently no continuous version of this job but it may get added.
 string(REGEX MATCH "(mac-arm-monterey-clang-bazel-nightly-debug|mac-arm-monterey-clang-bazel-continuous-debug|mac-arm-monterey-clang-bazel-experimental-debug)" REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")
 if(REGEX_MATCH_RESULT)
-  set(REMOTE_CACHE ON)
+  set(REMOTE_CACHE OFF)
 endif()
 # -- END TODO(svenevs)
 


### PR DESCRIPTION
To be restored when the cache server migration has been completed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/200)
<!-- Reviewable:end -->
