### PR TITLE
[cache] Re-enable mac-arm64 cache server

### DIFF
--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -48,7 +48,7 @@ if(REMOTE_CACHE)
 
   if(APPLE)
     if(APPLE_ARM64)
-      set(DASHBOARD_REMOTE_CACHE "http://10.221.188.4:6060")
+      set(DASHBOARD_REMOTE_CACHE "http://10.221.188.9:6060")
     else()
       set(DASHBOARD_REMOTE_CACHE "http://207.254.3.135")
     endif()

--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -166,21 +166,19 @@ if(REGEX_MATCH_RESULT)
   set(REMOTE_CACHE ON)
 endif()
 
-# TODO(svenevs): on 2023-02-16 we are undergoing a cache server migration on the
-# backend and need to disable it until the transition is complete.
 # TODO(svenevs): sort through the logic above and enable more (debug).
 # This expression is a temporary kludge to test out the cache with mac-arm using
 # the same jobs that mac-x86 is currently caching.
 string(REGEX MATCH "(mac-arm-monterey-clang-bazel-continuous-release|mac-arm-monterey-clang-bazel-experimental-everything-release|mac-arm-monterey-clang-bazel-experimental-release|mac-arm-monterey-clang-bazel-nightly-everything-release|mac-arm-monterey-clang-cmake-experimental-everything-release|mac-arm-monterey-clang-cmake-experimental-release|mac-arm-monterey-clang-cmake-nightly-everything-release|mac-arm-monterey-clang-cmake-nightly-release)" REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")
 if(REGEX_MATCH_RESULT)
-  set(REMOTE_CACHE OFF)
+  set(REMOTE_CACHE ON)
 endif()
 
 # We are also testing out running debug jobs with the new cache server.  There
 # is currently no continuous version of this job but it may get added.
 string(REGEX MATCH "(mac-arm-monterey-clang-bazel-nightly-debug|mac-arm-monterey-clang-bazel-continuous-debug|mac-arm-monterey-clang-bazel-experimental-debug)" REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")
 if(REGEX_MATCH_RESULT)
-  set(REMOTE_CACHE OFF)
+  set(REMOTE_CACHE ON)
 endif()
 # -- END TODO(svenevs)
 


### PR DESCRIPTION
- [X] Collect data / confirm expected results:
    - [Cache populate job](https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-experimental-release/66/): 1 hour 6 minutes
    - [Cache read job](https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-experimental-release/67/): :fire: 6 minutes 47 seconds :fire:
    - To be fair, that's building with 0 changes so it's basically just "download everything", but it's definitely working again :upside_down_face:
- Update URI for new cache server.
- This reverts commit 0f2c21584f017a5482ce03e04b8aaceb952746a9 (#200).



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/201)
<!-- Reviewable:end -->
