### PR TITLE
Restore "Run Gurobi tests in parallel (#194)"

### DIFF
--- a/driver/configurations/gurobi.cmake
+++ b/driver/configurations/gurobi.cmake
@@ -61,3 +61,6 @@ endif()
 
 # Always set environment variable so remote caches may be shared.
 set(ENV{GRB_LICENSE_FILE} "${GRB_LICENSE_FILE}")
+
+# Run Gurobi tests in parallel in the CI
+set(ENV{DRAKE_GUROBI_LICENSE_UNLIMITED} 1)


### PR DESCRIPTION
Restore #194 by reverting its revert commit (#199).

This reverts commit e0f93e61ea00b6419ede0fb71f7c986ed3dfeb71.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/202)
<!-- Reviewable:end -->
