### PR TITLE
Turn off symbols on Mac Debug builds

### DIFF
--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -246,6 +246,10 @@ if(APPLE)
   set(DASHBOARD_BAZEL_TEST_OPTIONS "${DASHBOARD_BAZEL_TEST_OPTIONS} --test_timeout=300,1500,4500,-1")
 endif()
 
+if(DEBUG AND APPLE)
+  set(DASHBOARD_BAZEL_TEST_OPTIONS "${DASHBOARD_BAZEL_TEST_OPTIONS} --copt=-g0 --host_copt=-g0")
+endif()
+
 configure_file("${DASHBOARD_TOOLS_DIR}/user.bazelrc.in" "${CTEST_SOURCE_DIRECTORY}/user.bazelrc" @ONLY)
 
 # Report build configuration


### PR DESCRIPTION
Mac debug CI jobs are running out of disk space.

Towards drake https://github.com/RobotLocomotion/drake/issues/18871

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/205)
<!-- Reviewable:end -->
