### PR TITLE
Enable --remote_download_minimal

### DIFF
--- a/tools/remote.bazelrc.in
+++ b/tools/remote.bazelrc.in
@@ -37,3 +37,4 @@ build --remote_max_connections=@DASHBOARD_REMOTE_MAX_CONNECTIONS@
 build --remote_retries=@DASHBOARD_REMOTE_RETRIES@
 build --remote_timeout=@DASHBOARD_REMOTE_TIMEOUT@
 build --remote_upload_local_results=@DASHBOARD_REMOTE_UPLOAD_LOCAL_RESULTS@
+build --remote_download_minimal


### PR DESCRIPTION
Baseline from master:
* https://drake-jenkins.csail.mit.edu/job/linux-jammy-gcc-bazel-experimental-debug/536/consoleFull
   * 333 seconds overall.
      * 288 seconds in bazel.
      * 45 seconds in prep / cleanup.
* https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-experimental-debug/9/consoleFull
   * ??? seconds overall.
      * ??? seconds in bazel.
      * ??? seconds in prep / cleanup.

Canary using this pull request:
 * https://drake-jenkins.csail.mit.edu/job/linux-jammy-gcc-bazel-experimental-debug/535/consoleFull
   * 69 seconds overall.
     * 34 seconds in bazel.
     * 35 seconds in prep / cleanup.
* https://drake-jenkins.csail.mit.edu/job/mac-arm-monterey-clang-bazel-experimental-debug/10/consoleFull
   * ??? seconds overall.
      * ??? seconds in bazel.
      * ??? seconds in prep / cleanup.

This risks https://github.com/bazelbuild/bazel/issues/8250 if our cache TTL is too low, but I am thinking we're probably safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/209)
<!-- Reviewable:end -->
