### PR TITLE
[cache] Temporarily disable cache servers for changeover

### DIFF
--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -40,6 +40,10 @@ set(DASHBOARD_OS_CACHE_VERSION)
 set(DASHBOARD_PYTHON_CACHE_VERSION)
 set(DASHBOARD_REMOTE_CACHE_KEY)
 
+# TODO(svenevs): remote cache disabled to bring the new cache server(s) and
+# updated configuration files online.
+set(REMOTE_CACHE OFF)
+
 if(REMOTE_CACHE)
   mktemp(DASHBOARD_FILE_DOWNLOAD_TEMP file_download_XXXXXXXX
     "temporary download file"


### PR DESCRIPTION
Confirmation builds (cancelled early, search logs for `REMOTE_CACHE_KEY_VERSION`):

- [X] drake-ci main mac: [cache used](https://drake-jenkins.csail.mit.edu/view/Experimental/job/mac-arm-monterey-clang-bazel-experimental-release/97/console)
- [X] drake-ci this pr mac: [cache not used](https://drake-jenkins.csail.mit.edu/view/Experimental/job/mac-arm-monterey-clang-bazel-experimental-release/98/console)
- [X] drake-ci main linux: [cache used](https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-release/12643/console)
- [X] drake-ci this pr mac: [cache not used](https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-release/12644/console)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/212)
<!-- Reviewable:end -->
