### PR TITLE
Revert "[cache] Temporarily disable cache servers for changeover"

### DIFF
--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -40,10 +40,6 @@ set(DASHBOARD_OS_CACHE_VERSION)
 set(DASHBOARD_PYTHON_CACHE_VERSION)
 set(DASHBOARD_REMOTE_CACHE_KEY)
 
-# TODO(svenevs): remote cache disabled to bring the new cache server(s) and
-# updated configuration files online.
-set(REMOTE_CACHE OFF)
-
 if(REMOTE_CACHE)
   mktemp(DASHBOARD_FILE_DOWNLOAD_TEMP file_download_XXXXXXXX
     "temporary download file"
@@ -52,7 +48,7 @@ if(REMOTE_CACHE)
 
   if(APPLE)
     if(APPLE_ARM64)
-      set(DASHBOARD_REMOTE_CACHE "http://10.221.188.9:6060")
+      set(DASHBOARD_REMOTE_CACHE "http://10.221.188.9")
     else()
       fatal("Caching is not supported for Mac x86 jobs.")
     endif()


### PR DESCRIPTION
Reverts RobotLocomotion/drake-ci#212

The macOS cache server is now on default port 80, not 6060.

- linux cache operational: https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-release/12645/console
- macOS cache operational: https://drake-jenkins.csail.mit.edu/view/Mac%20ARM/job/mac-arm-monterey-clang-bazel-experimental-release/100/console

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/213)
<!-- Reviewable:end -->
