### PR TITLE
[cache] Enable new linux cache server

### DIFF
--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -53,7 +53,7 @@ if(REMOTE_CACHE)
       fatal("Caching is not supported for Mac x86 jobs.")
     endif()
   else()
-    set(DASHBOARD_REMOTE_CACHE "http://172.31.20.109")
+    set(DASHBOARD_REMOTE_CACHE "http://172.31.19.73")
   endif()
   message(STATUS
       "Testing download of remote cache server: '${DASHBOARD_REMOTE_CACHE}'")


### PR DESCRIPTION
The new linux cache server is up and running and has been validated.  Its cache has subsequently been cleaned, please do not issue any more builds against this PR.

Once this merges all drake pull requests will be slow until nightly populates the cache.  Posting an update to [slack #buildcop channel](https://drakedevelopers.slack.com/archives/C270MN28G) indicating "The linux cache server has been swapped out, all Pull Request builds will be slow until nightly repopulates the cache tonight." would be nice.

- [X] Cache populate job:
    - https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-release/12646/consoleFull
    - 41min 18s
    - `--remote_cache=http://172.31.19.73/v3/cb67ff18dcac882caa72e2fc2b57a1441356b2cd549580fbb6e53135d05be77d`
- [X] Cache read job:
    - https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-release/12647/consoleFull
    - 3min 16s
    - `--remote_cache=http://172.31.19.73/v3/cb67ff18dcac882caa72e2fc2b57a1441356b2cd549580fbb6e53135d05be77d`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/215)
<!-- Reviewable:end -->
