### PR TITLE
[jammy] Install older mesa libraries

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -77,6 +77,27 @@ echo 'verbose = off' > /root/.wgetrc
 cp /root/.wgetrc /home/ubuntu/.wgetrc
 chown ubuntu:ubuntu /home/ubuntu/.wgetrc
 
+# Downgrade mesa per https://github.com/RobotLocomotion/drake/issues/18726.
+if [[ "$(lsb_release -cs)" == "jammy" ]]; then
+  # 1. Install the pinned versions we know work.
+  apt-get install -o Dpkg::Use-Pty=0 -y --allow-downgrades \
+    xvfb \
+    libegl1 \
+    libegl-mesa0=22.0.1-1ubuntu2 \
+    libgbm1=22.0.1-1ubuntu2 \
+    libgl1-mesa-dri=22.0.1-1ubuntu2 \
+    libglapi-mesa=22.0.1-1ubuntu2 \
+    libglx-mesa0=22.0.1-1ubuntu2
+  # 2. Prevent any subsequent `apt-get update && apt-get upgrade` from
+  #    installing the newer versions.
+  apt-mark hold \
+    libegl-mesa0 \
+    libgbm1 \
+    libgl1-mesa-dri \
+    libglapi-mesa \
+    libglx-mesa0
+fi
+
 cat << EOF > /lib/systemd/system/xvfb.service
 [Unit]
 After=network.target


### PR DESCRIPTION
Relates: https://github.com/RobotLocomotion/drake/issues/18726

- [X] BLOCKED: @svenevs will merge this in conjunction with backend updates when ready.

Testing:

- [X] Job verification on unprovisioned image built today:
    - [X] On `master/main` this is expected to fail: https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-clang-bazel-experimental-release/17/consoleFull
    - [X] With this PR, expected to pass: https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-clang-bazel-experimental-release/18/consoleFull
    - [X] With this PR, expected to pass: https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-clang-bazel-experimental-release/19/consoleFull
        - Needed to add `apt-mark hold` since this section of code is also used to build the provisioned images.  Without this subsequent `apt-get update && apt-get upgrade` in CI will just update us to the new broken ones.
    - [X] With this PR, focal should remain unchanged / pass: https://drake-jenkins.csail.mit.edu/job/linux-focal-unprovisioned-clang-bazel-experimental-release/59/consoleFull

- Previously these packages were simply being held in our jammy AMIs.  The AMI has needed an upgrade for unrelated reason, and now we have the newer versions.
- Until the underlying cause is known, we elect to install the older functional versions of the libraries and `apt-mark hold` them to bypass this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/217)
<!-- Reviewable:end -->
