### PR TITLE
[aws] Redirect bazel temporary directories on linux

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -82,5 +82,15 @@ fi
 AGENT=ssh-agent
 [[ "$SSH_PRIVATE_KEY_FILE" == '-' ]] && AGENT=
 
+# The root volumes on the AWS runners have 8GB of space in the root volume /,
+# which is configured in setup/ubuntu/init_script at /media/ephemeral0/ubuntu.
+# Set TEST_TMPDIR to somewhere on a larger volume, see:
+# https://bazel.build/remote/output-directories
+if [[ "$(uname -s)" == "Linux" ]]; then
+    readonly _bazel_tmp="/media/ephemeral0/ubuntu/bazel_cache"
+    mkdir -p "${_bazel_tmp}"
+    export TEST_TMPDIR="${_bazel_tmp}"
+fi
+
 # Hand off to the CMake driver script.
 $AGENT ctest --extra-verbose --no-compress-output --script "${CI_ROOT}/ctest_driver_script.cmake"


### PR DESCRIPTION
The Jammy AMI currently has ~500MB of free space, which causes many test failures.  Do not build under ~/.cache/bazel/..., instead use /media/ubuntu/ephemeral0 storage (which is much larger).

This was a temporary test solution to see if works.  The build got ~95% of the way through before I cancelled in favor of switching out to the new Jammy AMIs.  Opening the PR to close it again but keep the patch around in case we ever want to know "how can we force bazel to store things somewhere else".