### PR TITLE
[cache] Do not cache weekly jobs

### DIFF
--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -167,6 +167,13 @@ if(REGEX_MATCH_RESULT)
   set(REMOTE_CACHE ON)
 endif()
 
+# Do not cache weekly jobs, they run too infrequently to be useful and just
+# waste space on the cache server.
+string(REGEX MATCH ".*-weekly-.*" REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")
+if(REGEX_MATCH_RESULT)
+  set(REMOTE_CACHE OFF)
+endif()
+
 string(REGEX MATCH "(minsizerel|relwithdebinfo)" REGEX_MATCH_RESULT "${DASHBOARD_JOB_NAME}")
 if(REGEX_MATCH_RESULT)
   set(DEBUG OFF)


### PR DESCRIPTION
- [linux-focal-gcc-bazel-weekly-gurobi-release/155](https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-weekly-gurobi-release/155/consoleFull) (last week):

    ```
    [1:00:08 PM]    REMOTE_CACHE_KEY_VERSION       = v4
    [1:00:08 PM]    REMOTE_CACHE_KEY               = cb67ff18dcac882caa72e2fc2b57a1441356b2cd549580fbb6e53135d05be77d
    ```
- [linux-focal-gcc-bazel-weekly-gurobi-release/156](https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-weekly-gurobi-release/156/consoleFull) (running on this PR):

    ```
    [9:57:34 AM]    REMOTE_CACHE_KEY_VERSION       = 
    [9:57:34 AM]    REMOTE_CACHE_KEY               = 
    ```

    Job cancelled after it got past the point we were waiting for.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/219)
<!-- Reviewable:end -->
