### PR TITLE
[cache] Fix file removal strategy

### DIFF
--- a/cache_server/README.md
+++ b/cache_server/README.md
@@ -14,11 +14,9 @@ continuous integration details document.
 - mac-arm64:
     - Hosted on-site at MacStadium.  Requires TRI VPN to access.
     - 1TB SAN storage.
-    - IP address: `10.221.188.9`
 - linux:
-    - Hosted on AWS.  Requires Kitware VPN to access.
-    - 750GB EBS volume.
-    - IP address: `172.31.19.73`
+    - Hosted on AWS.  Requires Kitware or TRI VPN to access.
+    - 1TB EBS volume.
 
 ## Cache Server Overview
 
@@ -70,8 +68,14 @@ to simply setting the `bazel` cache server entries to different subdirectories.
 By convention:
 
 - Cache data storage volumes are mounted to `/cache`.
-- This repository should be cloned to `/cache/drake-ci`.
-- The logs are stored in `/cache/log/nginx/{access,error}.log`.
+- This repository should be cloned to `/opt/cache_server/drake-ci`.  Do not put
+  it on the same volume as the cache data storage.  If monitoring or file
+  removal are not working correctly, you will not be able to develop in
+  production (e.g., cannot `git pull` new files) or get new logging information.
+    - **NOTE**: this directory path is also used by
+      [`health_check.bash`](./health_check.bash).
+- The logs for `nginx`, file removal, and disk monitoring are are stored in
+  `/opt/cache_server/log`.
 - The build cache is written to `/cache/data`.  The [`cache.cmake`][cache_cmake]
   configuration sets as an example `DASHBOARD_REMOTE_CACHE_KEY_VERSION=v2`, so
   the action cache (ac) and content addressed storage (cas) will be stored at
@@ -83,66 +87,86 @@ All of the configuration options should be executed as `root`.
 
 1. Become the `root` user: `sudo -i -u root`
 
-2. Make the directory structure we need with ownership that `nginx` will be able
+2. When you first image a new cache server, make sure to fully upgrade it:
+
+    ```console
+    apt-get update && apt-get upgrade
+    ```
+
+    Pay attention to the output, if the kernel upgrades, make sure to `reboot`
+    it and prune the old kernels.  See the "Biannual Linux Kernel/Security
+    Update" section of the drake-ci document for more information.
+
+3. Make the directory structure we need with ownership that `nginx` will be able
    to work with:
 
     ```console
-    mkdir -p /cache/data /cache/log/nginx
-    chown -R www-data:www-data /cache/data /cache/log/nginx
+    (
+        mkdir -p \
+            /cache/data \
+            /opt/cache_server \
+            /opt/cache_server/log/nginx;
+        chown -R www-data:www-data /cache/data /opt/cache_server/log/nginx;
+    )
     ```
 
-3. Install the packages we need (and desire):
+4. Install the packages we need (and desire):
 
     ```console
-    $ apt-get install -y \
+    apt-get install -y \
         git \
+        python3-venv \
         nginx \
         nginx-extras \
         ncdu \
+        tmux \
         tree \
         vim
     ```
 
-4. Set the timezone to New York rather than UTC using
+5. Set the timezone to New York rather than UTC using
    `timedatectl set-timezone America/New_York`.  The timezone of the server is
    relevant for the `cron` entries that follow!
 
-5. Add the line `export EDITOR=vim` to the top of `/root/.bashrc`.  This way
+6. Add the line `export EDITOR=vim` to the top of `/root/.bashrc`.  This way
    when we run `crontab -e` later on, it will use `vim` rather than `nano`.
 
-6. Log out of `root` (`ctrl+d`) and log back in (`sudo -i -u root`) and confirm
+7. Log out of `root` (`ctrl+d`) and log back in (`sudo -i -u root`) and confirm
    `echo $EDITOR` prints `vim`.
 
-7. Clone this repository to `/cache/drake-ci`:
+8. Clone this repository to `/opt/cache_server/drake-ci`:
 
     ```console
-    $ (cd /cache && git clone https://github.com/RobotLocomotion/drake-ci.git)
+    (
+        cd /opt/cache_server && \
+        git clone https://github.com/RobotLocomotion/drake-ci.git
+    )
     ```
 
     Be aware that changing branches or making local edits to files on a cache
-    server under `/cache/drake-ci` affects a production system.  The pruning
-    routines under `cron` as well as monitoring scripts may behave unexpectedly
-    depending on what local changes are made.
+    server under `/opt/cache_server/drake-ci` affects a production system.  The
+    file removal routines under `cron` as well as Jenkins monitoring scripts may
+    behave unexpectedly depending on what local changes are made.
 
     Also be aware that changes to the `nginx` configuration (e.g., via
     `git pull`) do **not** go live.  The newly updated configuration should be
     validated by `nginx -t` and then the service must be restarted via
     `systemctl restart nginx`.
 
-8. Link our server configuration to `/etc/nginx/conf.d` (which is included by
+9. Link our server configuration to `/etc/nginx/conf.d` (which is included by
    `/etc/nginx/nginx.conf`):
 
     ```console
-    $ ln -s \
-        /cache/drake-ci/cache_server/drake_cache_server_nginx.conf \
+    ln -s \
+        /opt/cache_server/drake-ci/cache_server/drake_cache_server_nginx.conf \
         /etc/nginx/conf.d/
     ```
 
-9. Remove the default server (which also uses port 80):
-   `rm /etc/nginx/sites-enabled/default`.
+10. Remove the default server (which also uses port 80):
+    `rm /etc/nginx/sites-enabled/default`.
 
-10. Now that our server configurations are in place, verify that `nginx` is happy
-    with `nginx -t`:
+11. Now that our server configurations are in place, verify that `nginx` is
+    happy with `nginx -t`:
 
     ```console
     $ nginx -t
@@ -150,7 +174,7 @@ All of the configuration options should be executed as `root`.
     nginx: configuration file /etc/nginx/nginx.conf test is successful
     ```
 
-11. Restart `nginx`, and make sure it is configured to start on boot:
+12. Restart `nginx`, and make sure it is configured to start on boot:
 
     ```console
     $ systemctl restart nginx
@@ -177,32 +201,30 @@ All of the configuration options should be executed as `root`.
     Apr 07 16:53:18 tytrsr-ubuntu-01 systemd[1]: Started A high performance web server and a reverse proxy server.
     ```
 
-12. Confirm that `echo $USER` reveals you are `root`, and then execute
+13. Confirm that `echo $USER` reveals you are `root`, and then execute
     `crontab -e`.  Your final crontab entries for the `root` user should be:
 
     ```bash
     # This cache server's date / time are in America/New_York!
-    # Cache pruning: run 10pm eastern (before nightlies).
-    0 22 * * *   /cache/drake-ci/cache_server/remove_old_files.py --days 3 /cache/data >>/cache/log/remove_old_files.log 2>&1
+    # Cache pruning (https://crontab.guru/#0_8-22_*_*_*): every hour between 8am and
+    # 10pm.  Stop running in the evening to allow nightlies to be untouched.
+    0 8-22 * * *   /opt/cache_server/drake-ci/cache_server/remove_old_files.py auto /cache/data >>/opt/cache_server/log/remove_old_files.log 2>&1
     #
-    # Disk usage monitoring: run 7am eastern.
-    0 7  * * *   /cache/drake-ci/cache_server/disk_usage.py /cache/data >>/cache/log/disk_usage.log 2>&1
+    # Disk usage monitoring: 30 minutes after running the pruning.
+    30 8-22 * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/data >>/opt/cache_server/log/disk_usage_cache_data.log 2>&1
+    # Additionally monitor disk usage of the root volume.
+    30 8-22 * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py / >>/opt/cache_server/log/disk_usage_root.log 2>&1
     #
-    # Rotate cache logs.  Note that the verbose output of logrotate goes to the
-    # provided logfile, but it always overwrites.  We do not want it rotating
-    # itself, so it goes to /cache/logrotate.log (not /cache/log/logrotate.log).
-    # Run this daily after the other jobs are anticipated to finish: 10am eastern.
-    0 10 * * *   /usr/sbin/logrotate --verbose --log /cache/logrotate.log /cache/drake-ci/cache_server/logrotate_cache.conf >/dev/null 2>&1
+    # Rotate cache logs.  See the script for more information, this must be run
+    # frequently since the nginx access.log can grow quite quickly.  Run it when
+    # the other two jobs above are unlikely to also be running (and logging).
+    45 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/opt/cache_server/log/rotate_logs.log 2>&1
     ```
 
     You should be able to save and `cat /var/spool/cron/crontabs/root` to
     confirm.
 
-    **Important**: the `linux` cache server must be cleaned up more often,
-    currently it is being cleaned every `--days 2` but this value may update
-    in the future.
-
-13. Add the new cache server to `drake-ci` in a pull request that sets the
+14. Add the new cache server to `drake-ci` in a pull request that sets the
     appropriate `DASHBOARD_REMOTE_CACHE` value set at the top of
     [`cache.cmake`][cache_cmake].  To test the server (before merging the PR
     adding it), we will need to add two dummy commits to launch test jobs
@@ -242,11 +264,11 @@ All of the configuration options should be executed as `root`.
     + build --remote_upload_local_results=no
     ```
 
-14. After testing that the populate / read jobs work as desired, manually delete
+15. After testing that the populate / read jobs work as desired, manually delete
     the cache so that it starts clean when nightly / continuous begin running:
     `rm -rf /cache/data/*`
 
-15. Consult the drake continuous integration details document for the final
+16. Consult the drake continuous integration details document for the final
     steps needed to set up the cache server (copy over authentication
     credentials to enable the jenkins cache server monitoring jobs).
 
@@ -290,18 +312,27 @@ Once on the server, become the `root` user (`sudo -iu root`) and run a handful
 of different time windows using the `-n` (dry run) flag:
 
 ```console
-$ /cache/drake-ci/cache_server/remove_old_files.py -n --days 3 /cache/data/
-$ /cache/drake-ci/cache_server/remove_old_files.py -n --days 2 /cache/data/
-$ /cache/drake-ci/cache_server/remove_old_files.py -n --days 1 /cache/data/
-$ /cache/drake-ci/cache_server/remove_old_files.py -n --days 1 --hours 12 /cache/data/
+/opt/cache_server/drake-ci/cache_server/remove_old_files.py -n auto -t 60 /cache/data/
 ```
 
-Depending on how much disk space you need to free up, anything longer than 1.5
-days (`--days 1 --hours 12`) should be safe to delete immediately.  For a given
-cache server, if this happens multiple times then one of three changes must
-occur:
+Or manually search yourself:
+
+```
+$ /opt/cache_server/drake-ci/cache_server/remove_old_files.py -n manual --days 2 /cache/data/
+$ /opt/cache_server/drake-ci/cache_server/remove_old_files.py -n manual --days 1 /cache/data/
+$ /opt/cache_server/drake-ci/cache_server/remove_old_files.py -n manual --days 1 --hours 12 /cache/data/
+```
+
+While the data on the cache server itself is fairly easy to replace (it is never
+worth making a backup of this data), **be extremely conscious of what you are
+doing**.  If you delete the entire cache during the day, **all pull request
+builds will become over 10x slower** and will not speed up until continuous
+and/or nightly start repopulating the cache.
+
+Depending on your findings, likely you will want to choose one or more of:
 
 - Update the time interval for the `cron` job running
   [`remove_old_files.py`](./remove_old_files.py).
+- Change the disk percent usage threshold in the `cron` job`.
 - Increase the storage attached to the cache server.
 - Reduce the number of jenkins jobs that add to this cache server.

--- a/cache_server/drake_cache_server_nginx.conf
+++ b/cache_server/drake_cache_server_nginx.conf
@@ -4,8 +4,8 @@ server {
     server_name _;
 
     # Send the logging files to our own custom location.
-    access_log /cache/log/nginx/access.log;
-    error_log /cache/log/nginx/error.log;
+    access_log /opt/cache_server/log/nginx/access.log;
+    error_log /opt/cache_server/log/nginx/error.log;
 
     # Disable logging of "file not found" (do not log cache misses).
     log_not_found off;

--- a/cache_server/health_check.bash
+++ b/cache_server/health_check.bash
@@ -113,4 +113,4 @@ timeout 120 \
         -o StrictHostKeyChecking=no \
         -i "${cache_server_id_rsa_path}" \
         "root@${server_ip}" \
-        '/cache/drake-ci/cache_server/disk_usage.py /cache/data'
+        '/opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/data'

--- a/cache_server/logrotate_cache.conf
+++ b/cache_server/logrotate_cache.conf
@@ -1,10 +1,15 @@
-# Rotate logs if they grow past 100k, or each month, whichever is first.
+# Rotate logs if they grow past 100MB, or each month, whichever is first.
+# Note that the /opt/cache_server/log/nginx/access.log in particular grows very
+# quickly.  Logs are rotated hourly as a result, otherwise you can end up with
+# an access.log of >5GB.
+#
 # Logs will be rotated 10 times and then deleted.
+#
 # Note that the cron job running this is expected to execute daily.
-"/cache/log/*.log" "/cache/log/nginx/*.log" {
+"/opt/cache_server/log/*.log" "/opt/cache_server/log/nginx/*.log" {
     monthly
     missingok
     rotate 10
-    size 100k
-    maxsize 100k
+    size 100M
+    maxsize 100M
 }

--- a/cache_server/remove_old_files.py
+++ b/cache_server/remove_old_files.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
 """Remove old cache server data files.
 
-By default, files **accessed** more than 4 days ago will be deleted.  Since different
-servers may require different cache eviction strategies, it is also possible to request
-a different timedelta.  To keep the implementation simple (rather than trying to parse
-a :class:`python:datetime.timedelta` from the command line), a different timedelta can
-be created by supplying one of the supplemental time arguments ``--days``,
-``--seconds``, ``--minutes``, ``--hours``, and/or ``--weeks``.  These arguments are
-combined together to create the final timedelta, and each must be non-negative.  See:
+By default, files considered for deletion are determined based on access time, starting
+at 2 days ago.
 
-https://docs.python.org/3/library/datetime.html#datetime.timedelta
+**Automatic Mode**
+    By default seek approximately 70% utilization threshold of the volume, searching
+    more recent times if 2 days does not provide enough data to be removed.
+    WARNING: this mode can and will delete more data than would be required for the
+    provided utilization threshold.  It simply chooses the first value that will get
+    under the limit.
 
-.. note::
-
-    The default for days is always 4.  If you desire to delete all files that have not
-    been accessed within the last 5 hours, for example, you should supply both
-    ``--days 0`` and ``--hours 5``.  Providing just `--hours 5`` will result in four
-    days and five hours.
+**Manual Mode**
+    Remove files with an access time of 2 days ago or longer.  If you desire to delete
+    all files that have not been accessed within the last 5 hours, for example, you
+    must supply both ``--days 0`` and ``--hours 5``.  Providing just ``--hours 5`` will
+    result in two days and five hours.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import sys
 from datetime import datetime, timedelta
 from enum import Enum, unique
 from pathlib import Path
 
 from cache_logging import cache_logging_basic_setup, log_message
+
+DEFAULT_DELTA_MAX = timedelta(days=2)
+"""Default time duration for determining files to remove."""
 
 
 def bytes_to_human_string(size_bytes: int) -> str:
@@ -64,8 +67,31 @@ class TimeMetric(Enum):
     """Query ``st_mtime`` (time of last modification)."""
 
 
+@unique
+class Mode(Enum):
+    """Which file removal mode is being employed."""
+
+    AUTO = "auto"
+    """Automatic file removal mode: iteratively find the time metric needed to get the
+    filesystem storage below a certain threshold utilization."""
+
+    MANUAL = "manual"
+    """Manual file removal mode: remove files utilizing the provided time duration such
+    as --days 1 --hours 12."""
+
+
 class CacheDirectory:
     """Scan and encapsulate the cache directory, accumulating files to be pruned.
+
+    Usage:
+
+    1. Create the CacheDirectory instance once.  Accumulating the list of all files
+       takes the longest amount of time.
+    2. Call :func:`CacheDirectory.gather_files_for_removal` with your desired timedelta
+       to populate :attr:`CacheDirectory.files_to_remove`.
+    3. Repeat step 2 as desired with new timedelta, e.g., for :data:`Mode.AUTO`.
+    4. Call :func:`CacheDirectory.maybe_remove_files` to remove the list of files that
+       matched the latest gather / timedelta query (if not a dry run).
 
     **Attributes**
     root: Path
@@ -74,9 +100,6 @@ class CacheDirectory:
     time_metric: TimeMetric
         Which kind of time we are querying (access or modified time).
 
-    delta_max: timedelta
-        The timedelta used for querying file access time results.
-
     dry_run: bool
         If true, no files will be deleted, only metrics printed.
 
@@ -84,9 +107,13 @@ class CacheDirectory:
         The time at which scanning began for access time comparison to delta_max.
 
     files: list[tuple[Path, int, datetime]]
-        Candidates for deletion.  This list holds (file path, size bytes, access time)
-        tuples describing all files found under ``root`` that are older than ``delta``
-        time units.
+        The list of all files found.  Holds (file path, size bytes, access/modify time)
+        tuples describing files to consider for deletion.
+
+    files_to_remove: list[tuple[Path, int, datetime]]
+        Candidates for deletion.  This list holds
+        (file path, size bytes, access/modify time) tuples describing all files found
+        under ``root`` that are older than ``delta`` time units.
 
     invalid_files: list[tuple[Path, str]]
         A list of tuples (file path, error message) of files whose access times could
@@ -97,6 +124,9 @@ class CacheDirectory:
 
     size_bytes: int
         Total size in bytes of all files described by ``files`` attribute.
+
+    bytes_to_remove: int
+        Total size in bytes of all files described by ``files_to_remove`` attribute.
     """
 
     def __init__(
@@ -104,24 +134,25 @@ class CacheDirectory:
         *,
         root: Path,
         time_metric: TimeMetric,
-        delta_max: timedelta,
         dry_run: bool,
     ) -> None:
         self.root = root
         self.time_metric = time_metric
-        self.delta_max = delta_max
         self.dry_run = dry_run
         self.start_time = datetime.now()
         self.files: list[tuple[Path, int, datetime]] = []
+        self.files_to_remove: list[tuple[Path, int, datetime]] = []
         self.invalid_files: list[tuple[Path, str]] = []
         self.files_scanned = 0
         self.size_bytes = 0
+        self.bytes_to_remove = 0
 
         if self.time_metric == TimeMetric.ACCESS_TIME:
             time_attr = "st_atime"
         elif self.time_metric == TimeMetric.MODIFIED_TIME:
             time_attr = "st_mtime"
 
+        # Gather all files that can be potentially removed, storing their time metric.
         for directory_root, _, file_names in os.walk(self.root):
             directory_root_path = Path(directory_root)
             for f in file_names:
@@ -138,31 +169,56 @@ class CacheDirectory:
                     if time_query >= self.start_time:
                         continue
 
-                    # Add anything accessed/modified longer ago than the threshold.
-                    if (self.start_time - time_query) >= delta_max:
-                        self.files.append((f_path, f_stat.st_size, time_query))
-                        self.size_bytes += f_stat.st_size
+                    # Gather the list of all possible files once.
+                    self.files.append((f_path, f_stat.st_size, time_query))
+                    self.size_bytes += f_stat.st_size
                 except Exception as e:
                     self.invalid_files.append((f_path, str(e)))
 
-    def dump_stats(self) -> None:
-        """Print various statistics about the files and storage found."""
-        # If there are invalid files (likely only broken symlinks), print them all first
-        # so that the log has this information, but the more important data comes last.
+    def gather_files_for_removal(self, delta_max: timedelta):
+        """Returns total number of bytes that will be deleted by delta_max.
+
+        All files able to be deleted will be added to self.files_to_remove."""
+        self.bytes_to_remove = 0
+        self.files_to_remove.clear()
+        for f_path, size_bytes, time_query in self.files:
+            # Add anything accessed/modified longer ago than the threshold.
+            if (self.start_time - time_query) >= delta_max:
+                self.files_to_remove.append((f_path, size_bytes, time_query))
+                self.bytes_to_remove += size_bytes
+
+    def log_invalid_files(self):
+        # NOTE: rarely found in production, can happen when developers copy directories
+        # to stage a fake cache data volume and copy something with broken links.
         if self.invalid_files:
             log_message("--- INVALID FILES:")
             for f_path, err_msg in self.invalid_files:
                 log_message(f"INVALID: {f_path}: {err_msg}")
             log_message(f"--- END INVALID FILES ({len(self.invalid_files)} total)")
 
+    def log_total_storage_found(self):
+        log_message(f"Found: {self.files_scanned} total files.")
+        log_message(f"       {bytes_to_human_string(self.size_bytes)} total data.")
+
+    def log_files_to_remove(self):
+        log_message(f"Found: {len(self.files_to_remove)} file(s) to remove.")
+        log_message(
+            f"       {bytes_to_human_string(self.bytes_to_remove)} disk space "
+            "eligible for removal."
+        )
+
+    def log_all_statistics(self) -> None:
+        """Log all statistics about the files and storage found."""
+        # If there are invalid files (likely only broken symlinks), print them all first
+        # so that the log has this information, but the more important data comes last.
+        self.log_invalid_files()
+
         # Print out the most useful information last so it is readily available.
         log_message(f"==> {self.root}")
-        log_message(f"Found: {self.files_scanned} total files.")
-        log_message(f"{len(self.files)} file(s) eligible for pruning.")
-        human_readable = bytes_to_human_string(self.size_bytes)
-        log_message(f"{human_readable} disk space eligible for pruning.")
+        self.log_total_storage_found()
+        self.log_files_to_remove()
 
-    def maybe_prune(self) -> None:
+    def maybe_remove_files(self) -> None:
         """Print relevant data to the console and perform the pruning (if
         ``self.dry_run=False``)."""
         if not self.dry_run:
@@ -171,11 +227,11 @@ class CacheDirectory:
             # progress so the user knows it is still running.  Do not use
             # anything fancy such as carriage returns or a progress meter, the
             # logfile will be very disorganized.
-            n_files = len(self.files)
+            n_files = len(self.files_to_remove)
             n_format = len(str(n_files))  # to align [ x / {n_files} ]
             one_tenth = int(n_files // 10) + 1
             errors: list[tuple[Path, str]] = []  # (path, error message)
-            for i, (f_path, _, _) in enumerate(self.files):
+            for i, (f_path, _, _) in enumerate(self.files_to_remove):
                 if i == 0 or (i % one_tenth) == 0:
                     log_message(f"Removing file [{i+1: >{n_format}} / {n_files}] ...")
                 try:
@@ -197,7 +253,7 @@ def main() -> None:
     )
     parser.add_argument(
         "-m",
-        "--mode",
+        "--metric",
         type=str,
         choices=[tm.value for tm in TimeMetric],
         default=TimeMetric.ACCESS_TIME.value,
@@ -210,65 +266,66 @@ def main() -> None:
         action="store_true",
         help="Print what will be pruned without deleting.",
     )
-    parser.add_argument(
+
+    # NOTE: names for subparsers added must come from Mode enum.
+    subparsers = parser.add_subparsers(
+        help=f"Choose a removal mode: {','.join(m.value for m in Mode)}",
+        required=True,
+        dest="mode",
+    )
+    parser_auto = subparsers.add_parser(Mode.AUTO.value, help=Mode.AUTO.__doc__)
+    parser_auto.add_argument(
+        "-t",
+        "--threshold",
+        type=float,
+        default=70.0,
+        help=(
+            "Threshold to get disk utilization to (70.0 means target at most 70%% "
+            "utilized, or 30%% free).  Default: %(default)s.  Must be in range [1,99] "
+            "inclusive."
+        ),
+    )
+
+    parser_manual = subparsers.add_parser(
+        Mode.MANUAL.value,
+        help=Mode.MANUAL.__doc__,
+    )
+    parser_manual.add_argument(
         "--days",
         type=float,
-        default=4.0,
+        default=DEFAULT_DELTA_MAX.days,
         help="Number of days for the timedelta (default: %(default)s).",
     )
-    parser.add_argument(
-        "--seconds",
-        type=float,
-        default=0.0,
-        help="Number of seconds for the timedelta (default: %(default)s).",
-    )
-    parser.add_argument(
-        "--minutes",
-        type=float,
-        default=0.0,
-        help="Number of minutes for the timedelta (default: %(default)s).",
-    )
-    parser.add_argument(
+    parser_manual.add_argument(
         "--hours",
         type=float,
-        default=0.0,
+        default=DEFAULT_DELTA_MAX.seconds // 3600,
         help="Number of hours for the timedelta (default: %(default)s).",
     )
-    parser.add_argument(
-        "--weeks",
+    parser_manual.add_argument(
+        "--minutes",
         type=float,
-        default=0.0,
-        help="Number of weeks for the timedelta (default: %(default)s).",
+        default=(DEFAULT_DELTA_MAX.seconds // 60) % 60,
+        help="Number of minutes for the timedelta (default: %(default)s).",
     )
+
     # NOTE: add the positional argument last.
-    parser.add_argument(
-        "cache_dir",
-        type=Path,
-        help="Root directory to traverse and prune old files from.",
-    )
+    for sub_parser in (parser_auto, parser_manual):
+        sub_parser.add_argument(
+            "cache_dir",
+            type=Path,
+            help="Root directory to traverse and prune old files from.",
+        )
 
     args = parser.parse_args()
 
-    # Make sure all timedelta kwargs are positive to avoid invalid comparisons.
-    td_kwargs = {
-        "days": args.days,
-        "seconds": args.seconds,
-        "microseconds": 0,
-        "milliseconds": 0,
-        "minutes": args.minutes,
-        "hours": args.hours,
-        "weeks": args.weeks,
-    }
-    bad_kwargs = {}
-    for key, value in td_kwargs.items():
-        if value < 0.0:
-            bad_kwargs[key] = value
-    if bad_kwargs:
-        parser.error(
-            f"the following argument{'s' if len(bad_kwargs) > 1 else ''} "
-            "must be greater than or equal to 0: "
-            f"{', '.join(f'{k}={v}' for k, v in bad_kwargs.items())}"
-        )
+    # Overwrite with the enum value (argparse has issues with Enum).
+    if args.mode == Mode.AUTO.value:
+        mode = Mode.AUTO
+    elif args.mode == Mode.MANUAL.value:
+        mode = Mode.MANUAL
+    else:
+        parser.error(f"unrecognized mode: {args.mode}")
 
     # Make sure they provided us a directory.
     if not args.cache_dir.is_dir():
@@ -279,29 +336,128 @@ def main() -> None:
         parser.error("this script must be run as root!")
 
     # Create the enum value rather than a `str` (argparse has issues with Enum).
-    if args.mode == TimeMetric.ACCESS_TIME.value:
+    if args.metric == TimeMetric.ACCESS_TIME.value:
         time_metric = TimeMetric.ACCESS_TIME
-    elif args.mode == TimeMetric.MODIFIED_TIME.value:
+    elif args.metric == TimeMetric.MODIFIED_TIME.value:
         time_metric = TimeMetric.MODIFIED_TIME
     else:
         # This should be unreachable given how the argument is added with `choices`.
-        parser.error(f"unknown mode {args.mode}.")
+        parser.error(f"unknown time metric {args.metric}.")
 
-    delta_max = timedelta(**td_kwargs)
+    # Subparser specific validation.
+    delta_max = DEFAULT_DELTA_MAX
+    if mode == Mode.AUTO:
+        # Do not allow anything outside of [1,99] inclusive.
+        if args.threshold < 1.0 or args.threshold > 99.0:
+            parser.error(f"threshold {args.threshold}% invalid, must be in [1,99].")
+    else:  # Mode.MANUAL
+        # Make sure all timedelta kwargs are positive to avoid invalid comparisons.
+        td_kwargs = {
+            "days": args.days,
+            "seconds": 0.0,
+            "microseconds": 0,
+            "milliseconds": 0,
+            "minutes": args.minutes,
+            "hours": args.hours,
+            "weeks": 0,
+        }
+        bad_kwargs = {}
+        for key, value in td_kwargs.items():
+            if value < 0.0:
+                bad_kwargs[key] = value
+        if bad_kwargs:
+            parser.error(
+                f"the following argument{'s' if len(bad_kwargs) > 1 else ''} "
+                "must be greater than or equal to 0: "
+                f"{', '.join(f'{k}={v}' for k, v in bad_kwargs.items())}"
+            )
+        delta_max = timedelta(**td_kwargs)
 
     # Set up logging configurations.
     cache_logging_basic_setup()
     log_message(f"Age strategy:   {time_metric}")
     log_message(f"Time delta max: {delta_max}")
+    if args.dry_run:
+        log_message("NOTE: dry run, (no files will be removed).")
 
     cache_dir = CacheDirectory(
         root=args.cache_dir,
         time_metric=time_metric,
-        delta_max=delta_max,
         dry_run=args.dry_run,
     )
-    cache_dir.dump_stats()
-    cache_dir.maybe_prune()
+    if mode == Mode.AUTO:
+        try:
+            du = shutil.disk_usage(args.cache_dir)
+        except Exception as e:
+            parser.error(f"error collecting disk usage on '{args.cache_dir}': {e}")
+
+        # An invalid path may result in zero total size being reported.
+        if du.total <= 0:
+            parser.error(
+                f"the provided cache_dir='{args.cache_dir}' has zero total size."
+            )
+
+        # Iterate backward until we find a suitable number to delete.
+        current_percent_used = (du.used / du.total) * 100.0
+        min_possible_percent_used = (
+            (du.used - cache_dir.size_bytes) / du.total
+        ) * 100.0
+        if current_percent_used <= args.threshold:
+            log_message(
+                f"Disk usage for {args.cache_dir} is currently at "
+                f"{round(current_percent_used, 2)}%,\nwhich is beneath the requested "
+                f"threshold of {args.threshold}.\nNo files to remove."
+            )
+        elif min_possible_percent_used > args.threshold:
+            cache_dir.log_all_statistics()
+            parser.error(
+                f"cannot trim to {args.threshold}% usage, the {args.cache_dir} has "
+                f"{du.used} / {du.total} bytes used, and cumulatively "
+                f"{cache_dir.size_bytes} total bytes eligbile for removal were found.  "
+                "The best threshold that can be achieved is "
+                f"{round(min_possible_percent_used, 2)}%."
+            )
+        else:
+            log_message(f"==> {cache_dir.root}")
+            log_message(
+                f"Scanning for timedelta to achieve <= {args.threshold}% utilization:"
+            )
+            delta_max = DEFAULT_DELTA_MAX
+            # WARNING: keep this fairly small, searching is fast compared to initial
+            # file gather.  Larger windows (e.g., 2 hours) can result in 70% requests
+            # reducing to 50%, or 30% requests to 6%.  A lot of this is unpredictable,
+            # and depends primarily on PR merge rate on drake.
+            time_step = timedelta(minutes=15)
+            while (
+                delta_max.total_seconds() > 0 and current_percent_used > args.threshold
+            ):
+                cache_dir.gather_files_for_removal(delta_max)
+                new_du_used = du.used - cache_dir.bytes_to_remove
+                current_percent_used = (new_du_used / du.total) * 100.0
+                log_message(
+                    f"Delta: {delta_max} => {len(cache_dir.files_to_remove)} file(s), "
+                    f"{bytes_to_human_string(cache_dir.bytes_to_remove)} eligbile for "
+                    "removal"
+                )
+
+                delta_max -= time_step
+
+            # Even if delta_max.total_seconds() is why the loop terminated, remove.  In
+            # production we always need the space freed up.  The disk usage monitoring
+            # component is responsible for alerting when usage is too high.
+            if (delta_max + time_step).total_seconds() < 0:
+                log_message(
+                    "WARNING: loop terminated unable to find a small enough time "
+                    f"metric to satisfy {args.threshold}% utilization."
+                )
+
+            cache_dir.log_total_storage_found()
+            cache_dir.log_files_to_remove()
+            cache_dir.maybe_remove_files()
+    else:  # mode == Mode.MANUAL
+        cache_dir.gather_files_for_removal(delta_max)
+        cache_dir.log_all_statistics()
+        cache_dir.maybe_remove_files()
 
 
 if __name__ == "__main__":

--- a/cache_server/rotate_logs.py
+++ b/cache_server/rotate_logs.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Rotate log files using ``logrotate`` and restart ``nginx``.
+
+This script is expected to run by cron on an hourly schedule, see the associated
+``logrotate_cache.conf`` for the ``logrotate`` command which specifies the directories
+and rules for log files being rotated.
+
+After ``logrotate`` runs, however, the log files
+``/opt/cache_server/nginx/{access,error}.log`` may have been removed.  Running
+``nginx -s reload`` will close the file handles ``nginx`` had open to the previous
+(now possibly rotated to a new filename) log files, and open new ones.  Without
+reloading, all nginx logging for logs that have been rotated will stop.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import NoReturn
+
+from cache_logging import cache_logging_basic_setup, log_message
+
+
+def error(msg: str, exit_code: int = 1) -> NoReturn:
+    """
+    Print ``msg`` to ``stderr`` followed by a newline and exit with the provided code.
+    """
+    sys.stderr.write(msg)
+    sys.stderr.write("\n")
+    sys.exit(exit_code)
+
+
+def log_stdout_stderr(proc: subprocess.CompletedProcess):
+    """Log ``stdout`` and ``stderr`` of the completed process, if non-empty."""
+    stdout = proc.stdout.decode("utf-8").strip()
+    if stdout:
+        log_message(stdout)
+    stderr = proc.stderr.decode("utf-8").strip()
+    if stderr:
+        log_message(stderr)
+
+
+def main():
+    # Our cache servers are all linux and the commands below all assume this.
+    if platform.system() != "Linux":
+        error("This script only runs on linux.")
+
+    # This script must be run as root in order to create the right permissions and
+    # manage services.
+    if os.geteuid() != 0:
+        error("This script must be run as root.")
+
+    logrotate = shutil.which("logrotate")
+    if logrotate is None:
+        error("Could not find the `logrotate` command.  Is it installed?")
+
+    # Logs are stored in /opt/cache_server/log/.  Send the logging output of the
+    # ``logrotate`` command to /opt/cache_server/logrotate.log, and then re-log that to
+    # stdout (this script should run under cron and redirect to
+    # /opt/cache_server/log/rotate_logs.log).
+    this_file_dir = Path(__file__).parent.absolute()
+    logrotate_conf_path = this_file_dir / "logrotate_cache.conf"
+    if not logrotate_conf_path.is_file():
+        error(f"'{logrotate_conf_path}' is not a file.")
+
+    # ``logrotate`` setup.
+    opt_cache_server = Path("/opt") / "cache_server"
+    logrotate_log_path = opt_cache_server / "logrotate.log"
+    logrotate_log_path.unlink(missing_ok=True)
+    logrotate_args = [
+        logrotate,
+        "--verbose",
+        "--log",
+        str(logrotate_log_path),
+        str(logrotate_conf_path),
+    ]
+
+    cache_logging_basic_setup()
+    log_message(f"Running: {logrotate_args}")
+
+    # Run and log ``logrotate``.
+    logrotate_proc = subprocess.run(
+        logrotate_args,
+        capture_output=True,
+        check=True,
+    )
+    log_stdout_stderr(logrotate_proc)
+
+    # Log any messages from the ``logrotate`` logfile.  It gets recreated each time the
+    # command is run, so deleting after logging it is safe.
+    if logrotate_log_path.is_file():
+        with open(logrotate_log_path, "r") as f:
+            log_message(f.read().strip())
+        logrotate_log_path.unlink()
+
+    # Recreate the ``nginx`` logging files with the correct ownership in the event that
+    # ``logrotate`` deleted them.
+    log_message("Requesting nginx re-open its logfiles.")
+    nginx_proc = subprocess.run(
+        ["nginx", "-s", "reopen"], capture_output=True, check=True
+    )
+    log_stdout_stderr(nginx_proc)
+
+    # These calls are non-blocking, give time before checking.
+    sleep_duration = 3.0
+    log_message(f"Sleeping for {sleep_duration} seconds...")
+    time.sleep(sleep_duration)
+
+    log_message("Checking that nginx service is active:")
+    # Gives a non-zero exit code if it is not active.
+    systemctl_proc = subprocess.run(
+        ["systemctl", "is-active", "nginx"], capture_output=True, check=True
+    )
+    log_stdout_stderr(systemctl_proc)
+
+    nginx_log_dir = opt_cache_server / "log" / "nginx"
+    access_log = nginx_log_dir / "access.log"
+    error_log = nginx_log_dir / "error.log"
+    nginx_log_files = [access_log, error_log]
+    log_message(
+        "Verifying nginx logging files ("
+        f"{', '.join([str(f) for f in nginx_log_files])}):"
+    )
+    for f in nginx_log_files:
+        if not f.is_file():
+            error(f"Expected nginx log file '{f}' to be a file but it was not.")
+
+    # Fixup the permissions issues.
+    log_message(f"Changing ownership of {nginx_log_dir} to www-data:www-data.")
+    chown_proc = subprocess.run(
+        ["chown", "-R", "www-data:www-data", str(nginx_log_dir)],
+        capture_output=True,
+        check=True,
+    )
+    log_stdout_stderr(chown_proc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- remove_old_files.py:
    - Change defaults from 4 to 2 days.
    - Add `auto` mode to scan for disk utilization threshold, default: 70%.
    - Original behavior is now behind the `manual` mode. Allowed arguments reduced to days, hours, and minutes.
    - Rename / reorganize various methods to support the new modes.
- Update infrastructure skeleton to clone `drake-ci` and put logs in `/opt` (different mount point than `/cache` data volume).  If the the file removal or alerting system is not working, the `/cache` volume is full.  New logging information from nginx cannot be obtained, nor can developers `git pull` if `drake-ci` or logs are stored on the volume being monitored.
- Change cron schedules to remove files and monitor more aggressively.
- Add `logrotate` wrapper script that also reopens the nginx logging
  files.
    - Rotate logs much more aggresively to avoid >5GB acces.log files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/222)
<!-- Reviewable:end -->
