### PR TITLE
[cache] Add new linux cache server

### DIFF
--- a/cache_server/health_check.bash
+++ b/cache_server/health_check.bash
@@ -50,7 +50,7 @@ function usage() {
 readonly server_name="$1"
 case "${server_name}" in
     linux)
-        readonly server_ip="172.31.19.73"
+        readonly server_ip="172.31.25.87"
         ;;
 
     mac-arm64)

--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -59,7 +59,7 @@ if(REMOTE_CACHE)
       fatal("Caching is not supported for Mac x86 jobs.")
     endif()
   else()
-    set(DASHBOARD_REMOTE_CACHE "http://172.31.19.73")
+    set(DASHBOARD_REMOTE_CACHE "http://172.31.25.87")
   endif()
   message(STATUS
       "Testing download of remote cache server: '${DASHBOARD_REMOTE_CACHE}'")


### PR DESCRIPTION
Closes #225.  Relates: https://github.com/RobotLocomotion/drake/issues/19099#issuecomment-1585687628

- [X] BLOCKED: the EBS volume and elastic IP need to get switched back to the new instance.
- [X] Verify that cache server health check running on this branch works: [linux-focal-continuous-cache-server-health-check/138](https://drake-jenkins.csail.mit.edu/job/linux-focal-continuous-cache-server-health-check/138/consoleFull):

    ```
    [10:41:30 PM]  Commit message: "discard: test populate job"
    ...
    [10:41:31 PM]  + curl --fail --connect-timeout 10 -X GET 172.31.25.87/
    [10:41:31 PM]    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    [10:41:31 PM]                                   Dload  Upload   Total   Spent    Left  Speed
    [10:41:31 PM]  
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    100   365    0   365    0     0   356k      0 --:--:-- --:--:-- --:--:--  356k
    ....
    [10:41:33 PM]  + timeout 120 ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i /media/ephemeral0/ubuntu/workspace/linux-focal-continuous-cache-server-health-check/ci/cache_server/cache_server_id_rsa root@172.31.25.87 '/cache/drake-ci/cache_server/disk_usage.py /cache/data'
    ...
    [10:41:33 PM]  2023-06-14 22:41:33 :: ==> 63.85% usage is adequately beneath 85.0%
    ```
- [X] Cache populate job (partial, confirmed upload status on backend): [linux-focal-gcc-bazel-experimental-everything-release/7337](https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-everything-release/7337/consoleFull)

    ```
    [10:41:33 PM]  Commit message: "discard: test populate job"
    [10:42:01 PM]    REMOTE_CACHE_KEY_VERSION       = v4
    [10:42:01 PM]    REMOTE_CACHE_KEY               = 2985facb20bcb0738c3db18e48618a89a7f1125a92881ee25eae258b1d3a78fb
    [10:42:02 PM]    Inherited 'build' options: --experimental_guard_against_concurrent_changes=yes --remote_accept_cached=no --remote_cache=http://172.31.25.87/v4/2985facb20bcb0738c3db18e48618a89a7f1125a92881ee25eae258b1d3a78fb
    ```

    From server:
    
    ```
    172.31.21.202 - - [14/Jun/2023:22:43:01 -0400] "PUT /v4/2985facb20bcb0738c3db18e48618a89a7f1125a92881ee25eae258b1d3a78fb/cas/f884d7b72e122c53617f55042dbd1f5f319ca9f19ae9ce29d388131ea3efb0cb HTTP/1.1" 201 0 "-" "bazel/6.2.0"
    172.31.21.202 - - [14/Jun/2023:22:43:01 -0400] "PUT /v4/2985facb20bcb0738c3db18e48618a89a7f1125a92881ee25eae258b1d3a78fb/cas/5b1486ea034d6e5e8210b2e04599eb8b38f5cdfd1d44dcd74f9267863a9841ad HTTP/1.1" 201 0 "-" "bazel/6.2.0"
    ```
- [X] Cache read job: [linux-focal-gcc-bazel-experimental-everything-release/7338](https://drake-jenkins.csail.mit.edu/job/linux-focal-gcc-bazel-experimental-everything-release/7338/console)

    ```
    [10:44:32 PM]  Commit message: "discard: test read job"
    ...
    [10:45:08 PM]    REMOTE_CACHE_KEY_VERSION       = v4
    [10:45:08 PM]    REMOTE_CACHE_KEY               = 2985facb20bcb0738c3db18e48618a89a7f1125a92881ee25eae258b1d3a78fb
    ...
    [10:45:10 PM]    Inherited 'build' options: --experimental_guard_against_concurrent_changes=yes --remote_accept_cached=yes --remote_cache=http://172.31.25.87/v4/2985facb20bcb0738c3db18e48618a89a7f1125a92881ee25eae258b1d3a78fb
    ```
- [ ] Discard populate / read commits.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/226)
<!-- Reviewable:end -->
