### PR TITLE
[cache] Increase file removal frequency

### DIFF
--- a/cache_server/README.md
+++ b/cache_server/README.md
@@ -205,14 +205,24 @@ All of the configuration options should be executed as `root`.
     `crontab -e`.  Your final crontab entries for the `root` user should be:
 
     ```bash
-    # This cache server's date / time are in America/New_York!
-    # Cache pruning (https://crontab.guru/#0_8-22_*_*_*): every hour between 8am and
-    # 10pm.  Stop running in the evening to allow nightlies to be untouched.
-    0 8-22 * * *   /opt/cache_server/drake-ci/cache_server/remove_old_files.py auto /cache/data >>/opt/cache_server/log/remove_old_files.log 2>&1
+    # Important:  Scripts use this environment variable to detect if they are
+    # running under cron or not.
+    DRAKE_CRON_JOB=1
     #
-    # Disk usage monitoring: 30 minutes after running the pruning.
+    # This cache server's date / time are in America/New_York!
+    # Cache pruning (https://crontab.guru/#0_8-22_*_*_*): every 15 minutes
+    # between 8am and 10pm.  Stop running in the evening to allow nightlies to
+    # be untouched.
+    */15 8-22 * * *   /opt/cache_server/drake-ci/cache_server/remove_old_files.py auto /cache/data >>/opt/cache_server/log/remove_old_files.log 2>&1
+    #
+    # Disk usage monitoring: every 30 minutes.  Note that there is a continuous
+    # cache server health check job that runs on a completely unrelated
+    # schedule.  This log primarily exists as a backup for us to consult if we
+    # desire to monitor how much is deleted when.
     30 8-22 * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/data >>/opt/cache_server/log/disk_usage_cache_data.log 2>&1
-    # Additionally monitor disk usage of the root volume.
+    #
+    # Additionally monitor disk usage of the root volume.  This is where the
+    # logging data is stored.
     30 8-22 * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py / >>/opt/cache_server/log/disk_usage_root.log 2>&1
     #
     # Rotate cache logs.  See the script for more information, this must be run

--- a/cache_server/remove_old_files.py
+++ b/cache_server/remove_old_files.py
@@ -244,7 +244,18 @@ class CacheDirectory:
                 log_message("Errors found deleting files:")
                 for f_path, error_message in errors:
                     log_message(f"- {f_path}: {error_message}")
-                sys.exit(1)
+
+                # When this script is running under cron (see README.md, the
+                # crontab exports this environment variable), do not give a
+                # failing exit code if files could not be removed.  If two cron
+                # jobs are running at the same time, they may try to delete the
+                # same files, meaning one will error.
+                if "DRAKE_CRON_JOB" not in os.environ:
+                    log_message(
+                        "NOT failing the job as this ran from cron, another "
+                        "job may have already deleted the file(s) above."
+                    )
+                    sys.exit(1)
 
 
 def main() -> None:


### PR DESCRIPTION
- Removing files every hour is not frequent enough, use a shorter interval (15 minutes) for file removal.
- Have all `cron` scripts set a `DRAKE_CRON_JOB` variable so that we can identify if we ran from `cron`.
- remove_old_files.py: do not error when unable to delete files, the shorter window may lead to `cron` jobs fighting against one another in order to delete the same files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/236)
<!-- Reviewable:end -->
