### PR TITLE
[jenkins] Update macOS java version to match Jenkins

### DIFF
--- a/setup/mac/Brewfile
+++ b/setup/mac/Brewfile
@@ -38,5 +38,5 @@ tap 'robotlocomotion/director'
 brew 'awscli'
 brew 'cmake'
 
-cask 'adoptopenjdk8'
+cask 'temurin17'
 cask 'gurobi@10.0.2'


### PR DESCRIPTION
Follow-up to #245, relates: https://github.com/RobotLocomotion/drake/issues/18597

- [ ] :skull_and_crossbones: :no_entry_sign: :boom: DO NOT MERGE (testing in progress) :boom: :no_entry_sign: :skull_and_crossbones:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/246)
<!-- Reviewable:end -->
