### PR TITLE
[cache] Fix macOS Java version cache computation

### DIFF
--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -332,7 +332,7 @@ if(REMOTE_CACHE AND Java_JAVA_EXECUTABLE)
     message(STATUS "${DASHBOARD_JAVA_VERSION_ERROR_VARIABLE}")
     if(DASHBOARD_JAVA_VERSION_RESULT_VARIABLE EQUAL 0 AND
        DASHBOARD_JAVA_VERSION_ERROR_VARIABLE MATCHES
-       "^(java|openjdk) version \"([0-9]+[.][0-9]+[.][0-9]+(_[0-9]+)?)\""
+       "^(java|openjdk) version \"([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+(_[0-9]+)?)\""
     )
       set(DASHBOARD_JAVA_CACHE_VERSION "${CMAKE_MATCH_2}")
     else()


### PR DESCRIPTION
We switched drake-ci to use temurin during the jenkins update, there is an additional version number now.  This regex can be improved in the future if desired (trailing _[0-9] is not needed).

Relates: #245, #247, #248, https://github.com/RobotLocomotion/drake/issues/16779, https://github.com/RobotLocomotion/drake/issues/18597

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/249)
<!-- Reviewable:end -->
