### PR TITLE
Add centralized reporting of AWS uploads

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -138,6 +138,9 @@ endif()
 # Report disk usage after build
 execute_step(common report-disk-usage)
 
+# Report uploads (if any)
+execute_step(common report-uploads)
+
 # Remove any temporary files that we created
 foreach(_file ${DASHBOARD_TEMPORARY_FILES})
   file(REMOVE_RECURSE ${${_file}})

--- a/driver/configurations/common/step-report-uploads.cmake
+++ b/driver/configurations/common/step-report-uploads.cmake
@@ -1,0 +1,35 @@
+# -*- mode: cmake; -*-
+# vi: set ft=cmake:
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2018, Massachusetts Institute of Technology.
+# Copyright (c) 2018, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+aws_report()

--- a/driver/functions.cmake
+++ b/driver/functions.cmake
@@ -321,10 +321,23 @@ macro(aws_upload ARTIFACT UNSTABLE_MESSAGE)
       --bucket "drake-packages"
       --track "${DASHBOARD_TRACK}"
       --aws "${DASHBOARD_AWS_COMMAND}"
+      --log "${CTEST_BINARY_DIRECTORY}/aws_artifacts.log"
       "${ARTIFACT}"
     RESULT_VARIABLE DASHBOARD_AWS_UPLOAD_RESULT_VARIABLE)
   if(NOT DASHBOARD_AWS_UPLOAD_RESULT_VARIABLE EQUAL 0)
     append_step_status("${UNSTABLE_MESSAGE}" UNSTABLE)
+  endif()
+endmacro()
+
+#------------------------------------------------------------------------------
+# Report list of artifacts uploaded to AWS
+#------------------------------------------------------------------------------
+macro(aws_report)
+  if(EXISTS "${CTEST_BINARY_DIRECTORY}/aws_artifacts.log")
+    message(STATUS "Artifacts uploaded to AWS:")
+    execute_process(
+      COMMAND grep -vE "[.]sha[0-9]*\$"
+        "${CTEST_BINARY_DIRECTORY}/aws_artifacts.log")
   endif()
 endmacro()
 

--- a/tools/upload-to-aws.py
+++ b/tools/upload-to-aws.py
@@ -134,7 +134,11 @@ def upload(path, name, options, *, expiration=None):
                       f'after {MAX_ATTEMPTS} attempts', file=sys.stderr)
                 sys.exit(1)
 
-    print(f'-- Upload complete: {download_uri(name, options)}', flush=True)
+    uri = download_uri(name, options)
+    print(f'-- Upload complete: {uri}', flush=True)
+    if options.logfile is not None:
+        with open(options.logfile, 'a') as lf:
+            print(uri, file=lf)
 
 
 def upload_checksum(path, name, options, *, expiration=None):
@@ -219,6 +223,9 @@ def main(args):
     parser.add_argument(
         '--track', type=str.lower, required=True, choices=SUPPORTED_TRACKS,
         help='CI track of artifact')
+    parser.add_argument(
+        '--log', type=str, metavar='LOGFILE', dest='logfile',
+        help='Append list of uploaded URIs to %(metavar)s')
 
     options = parser.parse_args(args)
 


### PR DESCRIPTION
Modify AWS upload helper to accept an argument instructing it to record all upload URIs to a log file. Use this during all CI uploads. Add a step to dump the contents of this log file (if it exists) near the end of any CI run.

This gives us a single point of reporting the URIs of any uploads that happened during the job that should be relatively easy to find, rather than having them potentially scattered throughout the CI output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/250)
<!-- Reviewable:end -->
