### PR TITLE
[cache] Fix macOS java version regular expression

### DIFF
--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -332,7 +332,7 @@ if(REMOTE_CACHE AND Java_JAVA_EXECUTABLE)
     message(STATUS "${DASHBOARD_JAVA_VERSION_ERROR_VARIABLE}")
     if(DASHBOARD_JAVA_VERSION_RESULT_VARIABLE EQUAL 0 AND
        DASHBOARD_JAVA_VERSION_ERROR_VARIABLE MATCHES
-       "^(java|openjdk) version \"([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+(_[0-9]+)?)\""
+       "^(java|openjdk) version \"([0-9\.]+)\""
     )
       set(DASHBOARD_JAVA_CACHE_VERSION "${CMAKE_MATCH_2}")
     else()


### PR DESCRIPTION
The previous one was overly expressive, trying to match exactly `<major>.<minor>.<patch>.<build>?`.  When sonoma was unleased it was version `17.0.9` and the regex prior to this was only actually working for the ventura four digit `17.0.8.1`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/255)
<!-- Reviewable:end -->
