### PR TITLE
[docker] Enable `docker build` etc for Linux runners

### DIFF
--- a/setup/ubuntu/init_script
+++ b/setup/ubuntu/init_script
@@ -101,6 +101,14 @@ if [[ ! -d /media/ephemeral0/ubuntu ]]; then
   chmod u=rwx,go=rx /media/ephemeral0/ubuntu
 fi
 
+# Although `docker` may be installed at a later phase (via `install_prereqs`),
+# we need our build user to already be in that group before the login completes
+# and therefore need to do this unconditionally.  Previously this was a
+# provisioning step, but it is easier to keep it in the init script.  For
+# builds that are not using `docker`, this does exactly nothing meaningful.
+groupadd docker
+usermod -aG docker ubuntu
+
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update -o APT::Acquire::Retries=4 -qq \


### PR DESCRIPTION
Previously this was only provisioned in focal runners, now it should work across distribution upgrades as time moves on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/263)
<!-- Reviewable:end -->
