### PR TITLE
Adjust caching rcfile settings for Bazel 7 for CMake jobs

### DIFF
--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -118,6 +118,7 @@ include(${DASHBOARD_DRIVER_DIR}/configurations/cache.cmake)
 if(REMOTE_CACHE)
   file(APPEND "${DASHBOARD_SOURCE_DIRECTORY}/user.bazelrc"
     "build --experimental_guard_against_concurrent_changes=yes\n"
+    "build --remote_download_outputs=all\n"
     "build --remote_cache=${DASHBOARD_REMOTE_CACHE}\n"
     "build --remote_local_fallback=yes\n"
     "build --remote_max_connections=64\n"


### PR DESCRIPTION
This is the CMake equivalent of changes made in #266

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/267)
<!-- Reviewable:end -->
