### PR TITLE
Clarify cache server health check plan of action

### DIFF
--- a/cache_server/README.md
+++ b/cache_server/README.md
@@ -233,6 +233,9 @@ All of the configuration options should be executed as `root`.
     You should be able to save and `cat /var/spool/cron/crontabs/root` to
     confirm.
 
+    **Note**: if updating the `remove_old_files.py` cron job interval, please
+    also update the verbiage in `disk_usage.py` to match the new schedule.
+
 14. Add the new cache server to `drake-ci` in a pull request that sets the
     appropriate `DASHBOARD_REMOTE_CACHE` value set at the top of
     [`cache.cmake`][cache_cmake].  To test the server (before merging the PR

--- a/cache_server/disk_usage.py
+++ b/cache_server/disk_usage.py
@@ -95,7 +95,13 @@ def main() -> None:
 
             {percent_used:.2f}% usage exceeds provided threshold of {args.threshold}%
 
-            Please start a thread in the #buildcop slack channel delegating to Kitware:
+            The `remove_old_files.py` cron job runs every 15 minutes (e.g., at
+            12:00, 12:15, 12:30, and 12:45).  It can take up to 5 minutes to
+            complete, please wait until the automated file removal routine is
+            complete and re-launch this cache server health check job.
+
+            If it fails again, please start a thread in the #buildcop slack
+            channel delegating to Kitware:
 
                 https://drakedevelopers.slack.com/archives/C270MN28G
 


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/20911

Usually it will fix itself, and Kitware does not need to take any action.  Clarify to buildcops that it should fix itself shortly, and if not then ping Kitware.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/272)
<!-- Reviewable:end -->
