### PR TITLE
Fix/improve error reporting

### DIFF
--- a/driver/configurations/bazel/step-build.cmake
+++ b/driver/configurations/bazel/step-build.cmake
@@ -83,30 +83,24 @@ set(DASHBOARD_SUBMIT ON)
 # https://bazel.build/blog/2016/01/27/continuous-integration.html
 if(DASHBOARD_BUILD_RETURN_VALUE EQUAL 1)
   # Build failed.
-  set(DASHBOARD_FAILURE ON)
-  list(APPEND DASHBOARD_FAILURES "BAZEL BUILD")
+  append_step_status("BAZEL BUILD" FAILURE)
 elseif(DASHBOARD_BUILD_RETURN_VALUE EQUAL 2)
   # Command line problem, bad or illegal flags or command combination, or bad
   # environment variables. Your command line must be modified.
-  set(DASHBOARD_FAILURE ON)
-  list(APPEND DASHBOARD_FAILURES "BAZEL COMMAND OR ENVIRONMENT")
+  append_step_status("BAZEL COMMAND OR ENVIRONMENT" FAILURE)
 elseif(DASHBOARD_BUILD_RETURN_VALUE EQUAL 3)
   # Build OK, but some tests failed or timed out.
-  set(DASHBOARD_UNSTABLE ON)
-  list(APPEND DASHBOARD_UNSTABLES "BAZEL TEST")
+  append_step_status("BAZEL TEST" UNSTABLE)
 elseif(DASHBOARD_BUILD_RETURN_VALUE EQUAL 4)
   # Build successful, but no tests were found even though testing was requested.
-  set(DASHBOARD_UNSTABLE ON)
-  list(APPEND DASHBOARD_UNSTABLES "BAZEL TEST")
+  append_step_status("BAZEL TEST" UNSTABLE)
 elseif(DASHBOARD_BUILD_RETURN_VALUE EQUAL 8)
   # Build interrupted, but we terminated with an orderly shutdown.
-  set(DASHBOARD_FAILURE ON)
+  append_step_status("BAZEL BUILD OR TEST (BUILD INTERRUPTED)" FAILURE)
   set(DASHBOARD_SUBMIT OFF)
-  list(APPEND DASHBOARD_FAILURES "BAZEL BUILD OR TEST (BUILD INTERRUPTED)")
   message("*** Not submitting to CDash because build was interrupted")
 elseif(NOT DASHBOARD_BUILD_RETURN_VALUE EQUAL 0)
-  set(DASHBOARD_FAILURE ON)
-  list(APPEND DASHBOARD_FAILURES "BAZEL BUILD OR TEST (UNKNOWN ERROR)")
+  append_step_status("BAZEL BUILD OR TEST (UNKNOWN ERROR)" FAILURE)
 endif()
 
 if(DASHBOARD_SUBMIT)

--- a/driver/configurations/bazel/step-create-debian-archive.cmake
+++ b/driver/configurations/bazel/step-create-debian-archive.cmake
@@ -53,7 +53,6 @@ else()
     RESULT_VARIABLE DEBIAN_RESULT_VARIABLE)
 
   if(NOT DEBIAN_RESULT_VARIABLE EQUAL 0)
-    set(DASHBOARD_FAILURE ON)
     append_step_status(
       "BAZEL DEBIAN ARCHIVE CREATION (ERROR CODE=${DEBIAN_RESULT_VARIABLE})"
       UNSTABLE)
@@ -68,7 +67,6 @@ else()
     endif()
     set(repack_deb_path "${DASHBOARD_WORKSPACE}/${repack_deb_output}")
     if(NOT EXISTS "${repack_deb_path}")
-      set(DASHBOARD_FAILURE ON)
       append_step_status("BAZEL PACKAGE DEBIAN CREATION COULD NOT FIND ${repack_deb_output} in ${DASHBOARD_WORKSPACE}" UNSTABLE)
     else()
       # For the uploaded package name, we want to structure it to include the
@@ -89,7 +87,6 @@ else()
       endif()
       file(RENAME "${repack_deb_path}" "${DASHBOARD_WORKSPACE}/${DASHBOARD_DEBIAN_ARCHIVE_NAME}")
       if(NOT EXISTS "${DASHBOARD_WORKSPACE}/${DASHBOARD_DEBIAN_ARCHIVE_NAME}")
-        set(DASHBOARD_FAILURE ON)
         append_step_status("BAZEL PACKAGE DEBIAN CREATION COULD NOT RENAME ${repack_deb_path} to ${DASHBOARD_DEBIAN_ARCHIVE_NAME} in ${DASHBOARD_WORKSPACE}" UNSTABLE)
       else()
         message(STATUS "Debian archive created: ${DASHBOARD_DEBIAN_ARCHIVE_NAME}")

--- a/driver/configurations/wheel/step-build-and-test.cmake
+++ b/driver/configurations/wheel/step-build-and-test.cmake
@@ -64,8 +64,7 @@ set(DASHBOARD_SUBMIT ON)
 # https://bazel.build/blog/2016/01/27/continuous-integration.html
 if(NOT DASHBOARD_BUILD_RETURN_VALUE EQUAL 0)
   # Build failed.
-  set(DASHBOARD_FAILURE ON)
-  list(APPEND DASHBOARD_FAILURES "WHEEL BUILD")
+  append_step_status("WHEEL BUILD" FAILURE)
 endif()
 
 if(DASHBOARD_SUBMIT)


### PR DESCRIPTION
Always use append_step_status to communicate errors rather than setting the variables in situ. Don't treat Debian archive problems as both UNSTABLE and FAILURE, as this prevents the error from being communicated via the final status report. (Nothing downstream runs if the build is UNSTABLE, so treating these as FAILUREs is unnecessary.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/275)
<!-- Reviewable:end -->
