### PR TITLE
Fix error in previous change

### DIFF
--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -133,7 +133,7 @@ endif()
 
 # Set package version
 execute_step(common set-package-version)
-cache_append(DRAKE_VERSION_OVERRIDE "${DASHBOARD_DRAKE_VERSION}")
+cache_append(DRAKE_VERSION_OVERRIDE STRING "${DASHBOARD_DRAKE_VERSION}")
 
 # Report build configuration
 execute_step(common get-bazel-version)


### PR DESCRIPTION
Fix a minor error calling cache_append in the previous change to add CMake packaging builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/278)
<!-- Reviewable:end -->
