### PR TITLE
Exclude .github when publishing documentation

### DIFF
--- a/tools/publish_documentation.bash
+++ b/tools/publish_documentation.bash
@@ -36,7 +36,17 @@ doc="$2"
 
 export PATH="/usr/local/bin:${PATH}"
 git clone --quiet --single-branch git@github.com:RobotLocomotion/RobotLocomotion.github.io.git "${workspace}/gh-pages"
-rsync --archive --delete --exclude '*.map' --exclude '*.md5' --exclude .buildinfo --exclude .git --exclude .gitignore --exclude googleb54a1809ac854371.html --exclude LICENSE --exclude README.md --quiet "${doc}/" "${workspace}/gh-pages/"
+rsync --archive --delete \
+      --exclude '*.map' \
+      --exclude '*.md5' \
+      --exclude .buildinfo \
+      --exclude .git \
+      --exclude .github \
+      --exclude .gitignore \
+      --exclude googleb54a1809ac854371.html \
+      --exclude LICENSE \
+      --exclude README.md \
+      --quiet "${doc}/" "${workspace}/gh-pages/"
 cd "${workspace}/gh-pages"
 git config user.name drake-jenkins-bot
 git config user.email drake.jenkins.bot@gmail.com


### PR DESCRIPTION
Tweak `publish_documentation.bash` to also exclude `.github` from things that are deleted when copying the updated pages over to the publication repository. GitHub is dropping support for serving documentation without using GitHub Actions, which means we need to add GitHub Actions to that repository, which means not deleting them when the documentation changes is a Good Thing.

Toward RobotLocomotion/drake#21259.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/281)
<!-- Reviewable:end -->
