### PR TITLE
Update IP address for new cache server

### DIFF
--- a/cache_server/health_check.bash
+++ b/cache_server/health_check.bash
@@ -50,7 +50,7 @@ function usage() {
 readonly server_name="$1"
 case "${server_name}" in
     linux)
-        readonly server_ip="172.31.25.87"
+        readonly server_ip="172.31.18.175"
         ;;
 
     mac-arm64)

--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -55,7 +55,7 @@ if(REMOTE_CACHE)
   if(APPLE)
     set(DASHBOARD_REMOTE_CACHE "http://10.221.188.9")
   else()
-    set(DASHBOARD_REMOTE_CACHE "http://172.31.25.87")
+    set(DASHBOARD_REMOTE_CACHE "http://172.31.18.175")
   endif()
   message(STATUS
       "Testing download of remote cache server: '${DASHBOARD_REMOTE_CACHE}'")


### PR DESCRIPTION
Updates the IP to point at the new cache server.  See https://github.com/RobotLocomotion/drake/issues/19099.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/283)
<!-- Reviewable:end -->
