### PR TITLE
Don't pass --version to repack_deb

### DIFF
--- a/driver/configurations/cmake/step-create-debian-archive.cmake
+++ b/driver/configurations/cmake/step-create-debian-archive.cmake
@@ -40,8 +40,7 @@ else()
   set(DEBIAN_ARGS
     "run" "//tools/release_engineering:repack_deb" "--" "--tgz"
     "${DASHBOARD_WORKSPACE}/${DASHBOARD_PACKAGE_ARCHIVE_NAME}"
-    "--output-dir" "${DASHBOARD_WORKSPACE}"
-    "--version" "${DASHBOARD_DRAKE_VERSION}")
+    "--output-dir" "${DASHBOARD_WORKSPACE}")
   execute_process(COMMAND ${DASHBOARD_BAZEL_COMMAND} ${DEBIAN_ARGS}
     WORKING_DIRECTORY "${DASHBOARD_SOURCE_DIRECTORY}"
     RESULT_VARIABLE DEBIAN_RESULT_VARIABLE)


### PR DESCRIPTION
Now that we are reliably inserting real version numbers into VERSION.TXT, the repack_deb has been modified to use that as the source of the package version, and the --version option to the script has been deprecated. Therefore, stop using it so it can be removed entirely.

Relates to RobotLocomotion/drake#18145 and RobotLocomotion/drake#21364.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/285)
<!-- Reviewable:end -->
