### PR TITLE
Configure packaging builds via CMake (not user.bazelrc)

### DIFF
--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -108,17 +108,13 @@ cache_append(WITH_GUROBI BOOL ${DASHBOARD_WITH_GUROBI})
 cache_append(WITH_MOSEK BOOL ${DASHBOARD_WITH_MOSEK})
 cache_append(WITH_ROBOTLOCOMOTION_SNOPT STRING ${DASHBOARD_WITH_ROBOTLOCOMOTION_SNOPT})
 cache_append(WITH_OPENMP BOOL ${DASHBOARD_WITH_OPENMP})
+cache_append(DRAKE_CI_ENABLE_PACKAGING BOOL ${PACKAGE})
 
 file(COPY "${DASHBOARD_CI_DIR}/user.bazelrc"
   DESTINATION "${DASHBOARD_SOURCE_DIRECTORY}")
 
 file(APPEND "${DASHBOARD_SOURCE_DIRECTORY}/user.bazelrc"
   "startup --output_user_root=${DASHBOARD_WORKSPACE}/_bazel_$ENV{USER}\n")
-
-if(PACKAGE)
-  file(APPEND "${DASHBOARD_SOURCE_DIRECTORY}/user.bazelrc"
-    "build --config=packaging\n")
-endif()
 
 # Set up cache
 include(${DASHBOARD_DRIVER_DIR}/configurations/cache.cmake)


### PR DESCRIPTION
We always package using CMake, so we shouldn't be routing around its CMakeLists logic for what should mean.  This will allow Drake's CMakeLists.txt (not Bazel) to be the source of truth for what a packaging build should look like.

Requires RobotLocomotion/drake#22523.

Towards RobotLocomotion/drake#22519.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/302)
<!-- Reviewable:end -->
