### PR TITLE
Fix LCM traffic on macOS Sequoia

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -71,5 +71,13 @@ fi
 AGENT=ssh-agent
 [[ "$SSH_PRIVATE_KEY_FILE" == '-' ]] && AGENT=
 
+# macOS: Enable multicast traffic on loopback interface for LCM.
+# sudo is needed to modify the routing table
+if [[ "$(uname -s)" == Darwin ]]; then
+    sudo route -nv delete 224.0.0.0/4
+    sudo route -nv add -net 224.0.0.0/4 -interface lo0
+    netstat -nr
+fi
+
 # Hand off to the CMake driver script.
 $AGENT ctest --extra-verbose --no-compress-output --script "${CI_ROOT}/ctest_driver_script.cmake"


### PR DESCRIPTION
Addresses [#22322](https://github.com/RobotLocomotion/drake/issues/22322). Network config changes don't persist on the CI images, so this change has to go in a setup script that is run each time Jenkins deploys a VM. Currently, all other macOS setup scripts only run once, or they don't run on both provisioned and unprovisioned images. Running this command is required on Sequoia and harmless on Sonoma.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/303)
<!-- Reviewable:end -->
