### PR TITLE
Cleanup Doxygen files

### DIFF
--- a/tools/publish_documentation.bash
+++ b/tools/publish_documentation.bash
@@ -37,12 +37,7 @@ doc="$2"
 export PATH="/usr/local/bin:${PATH}"
 git clone --quiet --single-branch git@github.com:RobotLocomotion/RobotLocomotion.github.io.git "${workspace}/gh-pages"
 rsync --archive --delete \
-      --exclude '*.map' \
-      --exclude '*.md5' \
       --exclude .buildinfo \
-      --exclude .git \
-      --exclude .github \
-      --exclude .gitignore \
       --exclude googleb54a1809ac854371.html \
       --exclude LICENSE \
       --exclude README.md \


### PR DESCRIPTION
Addresses [#18554](https://github.com/RobotLocomotion/drake/issues/18554). See the corresponding [PR #22606](https://github.com/RobotLocomotion/drake/pull/22606) on Drake. 

* `*.md5` and `*.map` files are removed in the build now, instead of publish.
* `rsync` doesn't pick up on any git-related files, so this check is unnecessary.