### PR TITLE
Remove hard-coded server from pip index

### DIFF
--- a/tools/pip_index_url.py
+++ b/tools/pip_index_url.py
@@ -112,12 +112,11 @@ def main() -> None:
         )
     )
     for wheel in wheels:
-        server = "drake-packages.csail.mit.edu"
         s3_key, sha512, py_minor = (wheel.s3_key, wheel.sha512, wheel.py_minor)
         assert sha512 is not None, f"No sha512 found for {s3_key}"
         html.write(
             bytes(
-                f'<a href="https://{server}/{s3_key}#sha512={sha512}" '
+                f'<a href="/{s3_key}#sha512={sha512}" '
                 f'data-requires-python="&gt;=3.{py_minor},&lt;3.{py_minor+1}">'
                 f"{Path(s3_key).name}</a><br/>\n",
                 "utf-8",


### PR DESCRIPTION
The index file is necessarily on the same server.

This is relevant for when our main DNS entry goes down, to allow our other CNAME records for the same data to still serve requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/306)
<!-- Reviewable:end -->
