### PR TITLE
removed --no-lock brew option

### DIFF
--- a/setup/mac/install_prereqs
+++ b/setup/mac/install_prereqs
@@ -59,4 +59,4 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 brew analytics off
 brew update || (sleep 15; brew update)
 trap 'brew cleanup && rm -rf "$(brew --cache)" "${HOME}/Library/Logs/Homebrew/*"' EXIT
-brew bundle --file="$(dirname ${(%):-%x})/Brewfile" --no-lock
+brew bundle --file="$(dirname ${(%):-%x})/Brewfile"


### PR DESCRIPTION
Corresponding pr to [this change](https://github.com/RobotLocomotion/drake/pull/22704). Addresses the same underlying problem due to brew deprecating `--no-lock`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/307)
<!-- Reviewable:end -->
