### PR TITLE
Upload test output images to CDash

### DIFF
--- a/driver/configurations/bazel/step-build.cmake
+++ b/driver/configurations/bazel/step-build.cmake
@@ -116,6 +116,11 @@ if(DASHBOARD_SUBMIT)
     message(STATUS "Submitted to CDash with build id ${DASHBOARD_CDASH_BUILD_ID}")
   endif()
 
+  # Upload all image test results as uploaded files
+  file(GLOB_RECURSE TEST_OUTPUT_FILES FOLLOW_SYMLINKS "${DASHBOARD_SOURCE_DIRECTORY}/bazel-testlogs/*")
+  list(FILTER TEST_OUTPUT_FILES INCLUDE REGEX "test\\.outputs\\/")
+  ctest_upload(FILES ${TEST_OUTPUT_FILES} QUIET)
+
   ctest_submit(PARTS Upload
     RETRY_COUNT 4
     RETRY_DELAY 15


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/22251 by uploading all test image outputs to CDash.  The "right" way to do this is probably to add support for parsing Bazel test results directly to CTest, but we'll tackle that in a separate issue.  For now, putting images *somewhere* resolves the most pressing issue of not being able to see the images in a convenient place at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/311)
<!-- Reviewable:end -->
