### PR TITLE
Add alternate CMake/CTest location to PATH

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -45,7 +45,7 @@ if [[ "$(uname -s)" == Darwin && "$(uname -p)" != "arm" ]]; then
     fi
 fi
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/Applications/CMake.app/Contents/bin:${PATH}"
 
 # Provision image, if required.
 if [[ "${JOB_NAME}" =~ unprovisioned ]]; then


### PR DESCRIPTION
We recently moved to installing CMake manually on the Sequoia provisioned image, moving away from Homebrew CMake, as a fix for [#22587](https://github.com/RobotLocomotion/drake/issues/22587) and [#22460](https://github.com/RobotLocomotion/drake/issues/22460). The new location is `/Applications/CMake.app/Contents/bin`, which now needs to be appended to `$PATH`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/312)
<!-- Reviewable:end -->
