### PR TITLE
Add more verbose resource usage logs

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -121,8 +121,8 @@ set(DASHBOARD_CDASH_URL "")
 set(ENV{CMAKE_CONFIG_TYPE} "${DASHBOARD_CONFIGURATION_TYPE}")
 set(CTEST_CONFIGURATION_TYPE "${DASHBOARD_CONFIGURATION_TYPE}")
 
-# Report disk usage before build
-execute_step(common report-disk-usage)
+# Report resource usage before build
+execute_step(common report-resource-usage)
 
 # Invoke the appropriate build driver for the selected configuration
 if(GENERATOR STREQUAL "bazel")
@@ -135,8 +135,8 @@ else()
   fatal("generator is invalid")
 endif()
 
-# Report disk usage after build
-execute_step(common report-disk-usage)
+# Report resource usage after build
+execute_step(common report-resource-usage)
 
 # Report uploads (if any)
 execute_step(common report-uploads)

--- a/driver/configurations/common/step-report-resource-usage.cmake
+++ b/driver/configurations/common/step-report-resource-usage.cmake
@@ -50,28 +50,32 @@ if(NOT DASHBOARD_TEMP_DIR STREQUAL "/tmp")
   notice("Disk usage for /tmp:\n ${tmp_usage}")
 endif()
 
-# CPU and memory usage (overall and by process)
+# Overall memory usage
 
+# macOS doesn't have free...
 if(APPLE)
-  execute_process(COMMAND top -l 1 -s 0 | grep PhysMem
-    OUTPUT_VARIABLE dashboard_mem_usage
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(MEM_CMD "top -l 1 -s 0 | grep PhysMem")
 else()
-  # macOS doesn't have free...
-  execute_process(COMMAND free -m
-    OUTPUT_VARIABLE dashboard_mem_usage
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(MEM_CMD "free -m")
 endif()
 
-# This command has been carefully constructed to contain only options
-# supported on both Ubuntu and macOS.
-# `ps` differs slightly on the two systems for historical reasons.
-execute_process(COMMAND ps -o pid,user,%cpu,%mem,comm -ax | sort -b -k4 -r | head -11
-  OUTPUT_VARIABLE dashboard_mem_proc
+execute_process(COMMAND bash -c "${MEM_CMD}"
+  OUTPUT_VARIABLE dashboard_mem_usage
   ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 notice("Memory usage:\n ${dashboard_mem_usage}")
+
+# CPU and memory usage by process
+
+# This command has been carefully constructed to contain only options
+# supported on both Ubuntu and macOS.
+# `ps` differs slightly on the two systems for historical reasons.
+set(PS_CMD "ps -o pid,user,%cpu,%mem,comm -ax | sort -b -k4 -r | head -11")
+
+execute_process(COMMAND bash -c "${PS_CMD}"
+  OUTPUT_VARIABLE dashboard_mem_proc
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 notice("Processes using most memory:\n ${dashboard_mem_proc}")

--- a/driver/configurations/common/step-report-resource-usage.cmake
+++ b/driver/configurations/common/step-report-resource-usage.cmake
@@ -71,7 +71,12 @@ notice("Memory usage:\n ${dashboard_mem_usage}")
 # This command has been carefully constructed to contain only options
 # supported on both Ubuntu and macOS.
 # `ps` differs slightly on the two systems for historical reasons.
-set(PS_CMD "ps -o pid,user,%cpu,%mem,comm -ax | sort -b -k4 -r | head -11")
+# * get process ID, user, cpu+mem usage, and command
+# * print the header before (reverse-)sorting by memory
+# * print the top 10 processes (plus the header)
+set(PS_CMD "ps -o pid,user,%cpu,%mem,comm -ax |\
+            (read -r; printf \"%s\\n\" \"$REPLY\"; sort -brk 4) |\
+            head -n 11")
 
 execute_process(COMMAND bash -c "${PS_CMD}"
   OUTPUT_VARIABLE dashboard_mem_proc


### PR DESCRIPTION
Currently, we log disk usage before and after builds. It would also be useful to know memory usage -- how much is being used before/after, and by which processes? We can use this to identify extraneous processes running on CI machines that can be turned off to optimize build performance, and/or determine optimal build/test concurrency with Bazel.

(And while we're at it, since we use `ps` to get the top processes for memory usage, include CPU usage information for those processes as well. If the it's pertinent information, I'm willing to add a separate command which actually *sorts* by CPU usage so we can see top consumers there too, but figured what's here is a good start for now.)

CI examples of what these logs would look like:
* Linux Jammy: https://drake-jenkins.csail.mit.edu/job/linux-jammy-gcc-cmake-experimental-release/6001/
* macOS Sonoma: https://drake-jenkins.csail.mit.edu/job/mac-arm-sonoma-clang-cmake-experimental-release/22/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/317)
<!-- Reviewable:end -->
