### PR TITLE
Revert "[sonoma] Bypass SSL problems with CURL_SSL_BACKEND=SecureTransport (#261)"

### DIFF
--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -85,13 +85,6 @@ if(NOT DISTRIBUTION STREQUAL DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME)
   fatal("incorrect operating system code name in job name")
 endif()
 
-# TODO(20718): The next time we re-provision macOS Sonoma images, if the
-# underlying Curl and CMake have updated, we should be able to remove this
-# hack to get CDash job submissions to work.
-if(DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME STREQUAL "sonoma")
-  set(ENV{CURL_SSL_BACKEND} "SecureTransport")
-endif()
-
 if(DASHBOARD_JOB_NAME MATCHES "(clang|gcc)")
   set(COMPILER "${CMAKE_MATCH_0}")
 else()


### PR DESCRIPTION
See discussion for Drake issue [#20718](https://github.com/RobotLocomotion/drake/issues/20718#issuecomment-2783312285)

This reverts commit d36a0f73ac9a01b26fec696470b6e70691149699.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/318)
<!-- Reviewable:end -->
