### PR TITLE
Run chown for current user when using mkdir

### DIFF
--- a/driver/functions.cmake
+++ b/driver/functions.cmake
@@ -282,6 +282,22 @@ function(chmod PATH PERMISSIONS MESSAGE)
 endfunction()
 
 #------------------------------------------------------------------------------
+# Change ownership of a file or directory to the current user
+#------------------------------------------------------------------------------
+function(chown PATH)
+  execute_process(
+    COMMAND whoami
+    OUTPUT_VARIABLE _current_user
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(
+    COMMAND sudo chown ${_current_user} "${PATH}"
+    RESULT_VARIABLE _chown_result)
+  if(NOT _chown_result EQUAL 0)
+    fatal("Could not change ownership of ${PATH}")
+  endif()
+endfunction()
+
+#------------------------------------------------------------------------------
 # Create a directory with specified permissions
 #------------------------------------------------------------------------------
 function(mkdir PATH PERMISSIONS MESSAGE)
@@ -293,6 +309,7 @@ function(mkdir PATH PERMISSIONS MESSAGE)
     fatal("creation of ${MESSAGE} was not successful")
   endif()
   chmod("${PATH}" "${PERMISSIONS}" "${MESSAGE}")
+  chown("${PATH}")
 endfunction()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
When running `mkdir` while invoking `sudo`, the `root` user has ownership of the created directory instead of the calling user. Getting rid of `sudo` from this command addresses this problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/321)
<!-- Reviewable:end -->
