### PR TITLE
Update Jenkins agents to Java 21

### DIFF
--- a/driver/platform.cmake
+++ b/driver/platform.cmake
@@ -80,7 +80,7 @@ if(PROVISION)
     execute_process(COMMAND "${DASHBOARD_BREW_COMMAND}" "pin" "cmake")
     # Never upgrade temurin
     execute_process(COMMAND "${DASHBOARD_BREW_COMMAND}" "list"
-      COMMAND "grep" "--invert-match" "temurin@17"
+      COMMAND "grep" "--invert-match" "temurin@21"
       OUTPUT_VARIABLE to_upgrade)
     string(REPLACE "\n" ";" to_upgrade_list "${to_upgrade}")
     execute_process(COMMAND "${DASHBOARD_BREW_COMMAND}" "upgrade" ${to_upgrade_list} "--force")

--- a/setup/ubuntu/ami_init_script
+++ b/setup/ubuntu/ami_init_script
@@ -43,10 +43,10 @@ trap 'set +x; rm -rf /var/cache/apt/archives/*.deb /var/cache/apt/archives/parti
 
 apt-get install --no-install-recommends -o APT::Acquire::Retries=4 -o Dpkg::Use-Pty=0 -qy \
   git \
-  openjdk-17-jre-headless \
+  openjdk-21-jre-headless \
   openssh-client
 
-update-java-alternatives --jre-headless -s java-1.17.0-openjdk-amd64
+update-java-alternatives --jre-headless -s java-1.21.0-openjdk-amd64
 
 groupadd docker
 usermod -a -G docker ubuntu

--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -72,7 +72,7 @@ apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
   git \
   gnupg \
   lsb-release \
-  openjdk-17-jre-headless \
+  openjdk-21-jre-headless \
   python3-venv \
   wget \
   xvfb


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/22890. 

* For Ubuntu, this change is a prerequisite to both the image preparation (`ami_init_script`, which is for unprovisioned and provisioned images) and the deployment/transition itself (`install_prereqs`).
* For macOS, this change is only needed for the deployment/transition itself, as we don't install `temurin` as part of the CI scripts but rather do that by hand.

I verified that `openjdk-21-jre-headless` is available on both Jammy and Noble, so we don't have to do the special-case logic like we do for `awscli`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/322)
<!-- Reviewable:end -->
