### PR TITLE
Re-enable --remote_download_outputs=minimal

### DIFF
--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -120,7 +120,8 @@ include(${DASHBOARD_DRIVER_DIR}/configurations/cache.cmake)
 if(REMOTE_CACHE)
   file(APPEND "${DASHBOARD_SOURCE_DIRECTORY}/user.bazelrc"
     "build --experimental_guard_against_concurrent_changes=yes\n"
-    "build --remote_download_outputs=all\n"
+    "build --remote_download_outputs=minimal\n"
+    "build --experimental_remote_cache_lease_extension=yes\n"
     "build --remote_cache=${DASHBOARD_REMOTE_CACHE}\n"
     "build --remote_local_fallback=yes\n"
     "build --remote_max_connections=64\n"

--- a/tools/remote.bazelrc.in
+++ b/tools/remote.bazelrc.in
@@ -31,6 +31,7 @@
 
 build --experimental_guard_against_concurrent_changes=yes
 build --remote_download_outputs=minimal
+build --experimental_remote_cache_lease_extension=yes
 build --remote_accept_cached=@DASHBOARD_REMOTE_ACCEPT_CACHED@
 build --remote_cache=@DASHBOARD_REMOTE_CACHE@
 build --remote_local_fallback=yes

--- a/tools/remote.bazelrc.in
+++ b/tools/remote.bazelrc.in
@@ -30,7 +30,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 build --experimental_guard_against_concurrent_changes=yes
-build --remote_download_outputs=all
+build --remote_download_outputs=minimal
 build --remote_accept_cached=@DASHBOARD_REMOTE_ACCEPT_CACHED@
 build --remote_cache=@DASHBOARD_REMOTE_CACHE@
 build --remote_local_fallback=yes


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/21121, reverts https://github.com/RobotLocomotion/drake-ci/pull/298, accompanied by https://github.com/RobotLocomotion/drake/pull/22929.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/323)
<!-- Reviewable:end -->
