### PR TITLE
[Ubuntu] Remove unnecessary packages from `install_prereqs`

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -69,10 +69,8 @@ fi
 apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
   ca-certificates \
   cmake \
-  git \
   gnupg \
   lsb-release \
-  openjdk-21-jre-headless \
   python3-venv \
   wget \
   xvfb


### PR DESCRIPTION
We install `git` and `openjdk-*-jre-headless` as part of the `ami_init_script`, and in fact, Jenkins _shouldn't_ be able to use the images if we didn't. The installation on each unprovisioned job is therefore redundant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/325)
<!-- Reviewable:end -->
