### PR TITLE
[ubuntu jammy] Add apt hold for `grub`

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -50,6 +50,16 @@ echo 'APT::Acquire::Retries "4";' > /etc/apt/apt.conf.d/80-acquire-retries
 export DEBIAN_FRONTEND=noninteractive
 export PYTHONWARNINGS=ignore::SyntaxWarning
 
+# Prevent updates for boot- and AWS-related packages.
+if [[ "$(lsb_release -cs)" == "jammy" ]]; then
+  apt-mark hold \
+    grub-efi-amd64-bin \
+    grub-efi-amd64-signed \
+    linux-aws \
+    linux-headers-aws \
+    linux-image-aws
+fi
+
 apt-get update -qq || (sleep 15; apt-get update -qq)
 trap 'set +x; rm -rf /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin /var/lib/apt/lists/* /var/log/apt/*; set -x' EXIT
 


### PR DESCRIPTION
Linux Jammy unprovisioned jobs started failing (e.g. https://drake-jenkins.csail.mit.edu/view/Production/job/linux-jammy-unprovisioned-clang-bazel-nightly-everything-release/1044/) while installing these `grub-efi-amd64` packages. They don't need to be `apt update`/`upgrade`d and are now causing issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/330)
<!-- Reviewable:end -->
