### PR TITLE
[cache] Rotate log files more frequently

### DIFF
--- a/cache_server/README.md
+++ b/cache_server/README.md
@@ -218,12 +218,12 @@ All of the configuration options should be executed as `root`.
     #
     # Additionally monitor disk usage of the root volume.  This is where the
     # logging data is stored.
-    40 * * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py / >>/opt/cache_server/log/disk_usage_root.log 2>&1
+    40 * * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py / -t 70 >>/opt/cache_server/log/disk_usage_root.log 2>&1
     #
     # Rotate cache logs.  See the script for more information, this must be run
     # frequently since the nginx access.log can grow quite quickly.  Run it when
     # the other two jobs above are unlikely to also be running (and logging).
-    45 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/opt/cache_server/log/rotate_logs.log 2>&1
+    10-59/15 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/opt/cache_server/log/rotate_logs.log 2>&1
     ```
 
     You should be able to save and `cat /var/spool/cron/crontabs/root` to


### PR DESCRIPTION
The nginx `access.log` files are building up in large excess of the 100 MB set in `logrotate_cache.conf` (up to triple the size in some cases, which is significant when we have 10 rotations). The solution here is to rotate them more often --- every 15 minutes, instead of hourly --- so that the size gets caught before blowing up too much. We also offset it from the other two cron jobs so that the log files don't clash.

Also, amends c1061a349ab1860ca2fa86a2f2780db9c8093989 to update the threshold in the cron job for monitoring `/` with the same value as is present in `health_check.bash`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/332)
<!-- Reviewable:end -->
