### PR TITLE
Allow macOS jobs to use the remote cache

### DIFF
--- a/cache_server/logrotate_cache.conf
+++ b/cache_server/logrotate_cache.conf
@@ -1,4 +1,4 @@
-# Rotate logs if they grow past 100MB, or each month, whichever is first.
+# Rotate logs if they grow past 150MB, or each month, whichever is first.
 # Note that the /opt/cache_server/log/nginx/access.log in particular grows very
 # quickly.  Logs are rotated hourly as a result, otherwise you can end up with
 # an access.log of >5GB.
@@ -10,6 +10,6 @@
     monthly
     missingok
     rotate 10
-    size 100M
-    maxsize 100M
+    size 150M
+    maxsize 150M
 }

--- a/driver/configurations/cache.cmake
+++ b/driver/configurations/cache.cmake
@@ -318,8 +318,6 @@ if(REMOTE_CACHE AND Java_JAVA_EXECUTABLE)
 endif()
 
 
-# NOTE: As of 4/10/25, the remote cache is disabled on all macOS jobs,
-# but this logic will be left here for if/when it is set up again for AWS.
 if(APPLE)
   if(REMOTE_CACHE)
     set(DASHBOARD_OS_CACHE_NAME "macos")

--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -131,9 +131,7 @@ endif()
 
 set(REMOTE_CACHE ON)
 
-# NOTE: As of 4/10/25, the remote cache is disabled on all macOS jobs
-# as they're hosted in AWS.
-if(DASHBOARD_JOB_NAME MATCHES "(health-check|unprovisioned|packaging)" OR APPLE)
+if(DASHBOARD_JOB_NAME MATCHES "(health-check|unprovisioned|packaging)")
   set(REMOTE_CACHE OFF)
 endif()
 


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/22997. We disabled the remote cache for all macOS jobs in #316 as part of the transition to AWS, since the Mac Stadium cache server would no longer be in use. Here, we'll try pointing it to the same cache server as Linux uses.

If we end up using this long-term, it might be worth cleaning up some of the code and comments in `cache.cmake` and `health_check.bash`, since the general design there was to have arguments/options for multiple cache servers. 