### PR TITLE
Apply consistent CTest site naming to macOS and Linux

### DIFF
--- a/driver/site.cmake
+++ b/driver/site.cmake
@@ -33,13 +33,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Set site
-if(APPLE)
-  string(REGEX REPLACE "(.*)_(.*)" "\\1"
-    DASHBOARD_NODE_NAME "${DASHBOARD_NODE_NAME}")
-else()
-  string(REGEX REPLACE "(.*) - (.*) (.*)" "\\2"
-    DASHBOARD_NODE_NAME "${DASHBOARD_NODE_NAME}")
-endif()
+string(REGEX REPLACE "(.*) - (.*) (.*)" "\\2"
+  DASHBOARD_NODE_NAME "${DASHBOARD_NODE_NAME}")
 set(CTEST_SITE "${DASHBOARD_NODE_NAME}")
 
 # set model and track for submission


### PR DESCRIPTION
In #316, we missed some special logic being applied to `CTEST_SITE` to parse the image name. Since everything lives in EC2 now, the same string parsing can be applied to both Linux and macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/337)
<!-- Reviewable:end -->
