### PR TITLE
Remove `--experimental_guard_against_concurrent_changes`

### DIFF
--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -122,7 +122,6 @@ include(${DASHBOARD_DRIVER_DIR}/configurations/cache.cmake)
 
 if(REMOTE_CACHE)
   file(APPEND "${DASHBOARD_SOURCE_DIRECTORY}/user.bazelrc"
-    "build --experimental_guard_against_concurrent_changes=yes\n"
     "build --remote_download_outputs=all\n"
     "build --remote_cache=${DASHBOARD_REMOTE_CACHE}\n"
     "build --remote_local_fallback=yes\n"

--- a/tools/remote.bazelrc.in
+++ b/tools/remote.bazelrc.in
@@ -29,7 +29,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-build --experimental_guard_against_concurrent_changes=yes
 build --remote_download_outputs=all
 build --experimental_remote_cache_lease_extension=yes
 build --remote_accept_cached=@DASHBOARD_REMOTE_ACCEPT_CACHED@


### PR DESCRIPTION
Bazel 8.3.x deprecates the "experimental" part and makes it a full-fledged flag. It was originally intended to prevent race conditions with the remote cache when input files are modified during a build.

Now, the default behavior is 'lite', which checks this only for sources in the main repository (as opposed to 'full', which includes all externals but sacrifices performance, or 'off').

For more context, see:

* [Bazel docs](https://bazel.build/reference/command-line-reference#common_options-flag--guard_against_concurrent_changes)
* https://github.com/bazelbuild/bazel/issues/3360
* https://github.com/bazelbuild/bazel/pull/25874

Closes https://github.com/RobotLocomotion/drake/issues/23181.
