### PR TITLE
Add DRAKE_VERSION to CMake build log

### DIFF
--- a/ctest_driver_script.cmake
+++ b/ctest_driver_script.cmake
@@ -40,7 +40,7 @@
 #   ENV{CHANGE_ID}             optional
 #   ENV{CHANGE_TITLE}          optional
 #   ENV{CHANGE_URL}            optional
-#   ENV{DRAKE_VERSION}         required for wheel staging builds
+#   ENV{DRAKE_VERSION}         required for staging builds
 #   ENV{ghprbPullId}           optional
 #   ENV{ghprbPullLink}         optional
 #   ENV{ghprbPullTitle}        optional

--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -190,6 +190,7 @@ report_configuration("
   ==================================== >DASHBOARD_
   GIT_COMMIT
   ACTUAL_GIT_COMMIT
+  DRAKE_VERSION
   ==================================== >DASHBOARD_
   ${COMPILER_UPPER}_CACHE_VERSION(CC_CACHE_VERSION)
   GFORTRAN_CACHE_VERSION


### PR DESCRIPTION
Match logging for wheel and CMake packaging configurations which are the two used for staging builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/342)
<!-- Reviewable:end -->
