### PR TITLE
Only upload Bazel testlogs to CDash if they exist

### DIFF
--- a/driver/configurations/bazel/step-build.cmake
+++ b/driver/configurations/bazel/step-build.cmake
@@ -119,7 +119,14 @@ if(DASHBOARD_SUBMIT)
   # Upload all image test results as uploaded files
   file(GLOB_RECURSE TEST_OUTPUT_FILES FOLLOW_SYMLINKS "${DASHBOARD_SOURCE_DIRECTORY}/bazel-testlogs/*")
   list(FILTER TEST_OUTPUT_FILES INCLUDE REGEX "test\\.outputs\\/")
-  ctest_upload(FILES ${TEST_OUTPUT_FILES} QUIET)
+  if (TEST_OUTPUT_FILES)
+    ctest_upload(FILES ${TEST_OUTPUT_FILES}
+      CAPTURE_CMAKE_ERROR DASHBOARD_SUBMIT_UPLOAD_CAPTURE_CMAKE_ERROR
+      QUIET)
+      if(DASHBOARD_SUBMIT_UPLOAD_CAPTURE_CMAKE_ERROR EQUAL -1)
+        message(WARNING "*** CTest submit upload Bazel test logs was not successful")
+      endif()
+  endif()
 
   ctest_submit(PARTS Upload
     RETRY_COUNT 4


### PR DESCRIPTION
Amend b6046ee. This resolves a bug where trying to call `ctest_upload` with no files would somehow mess up the label being applied to the job (see: `DASHBOARD_LABEL`).

Closes RobotLocomotion/drake#23265.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/344)
<!-- Reviewable:end -->
