### PR TITLE
Move macOS Gurobi installation to bash script

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -47,12 +47,9 @@ fi
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
 
-# Provision image, if required.
-if [[ "${JOB_NAME}" =~ unprovisioned ]]; then
-    case "$(uname -s)" in
-        (Darwin) "${CI_ROOT}/setup/mac/install_prereqs";;
-        (Linux) sudo --preserve-env "${CI_ROOT}/setup/ubuntu/install_prereqs";;
-    esac
+# Provision image, if required (Linux only).
+if [[ "$(uname -s)" == "Linux" && "${JOB_NAME}" =~ unprovisioned ]]; then
+    sudo --preserve-env "${CI_ROOT}/setup/ubuntu/install_prereqs"
 fi
 
 # Synchronize the system clock (so log timestamps will be accurate).

--- a/setup/mac/Brewfile
+++ b/setup/mac/Brewfile
@@ -32,9 +32,5 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-tap 'robotlocomotion/director'
-
 brew 'awscli'
 brew 'cmake'
-
-cask 'gurobi1002'

--- a/setup/mac/install_prereqs
+++ b/setup/mac/install_prereqs
@@ -60,3 +60,9 @@ brew analytics off
 brew update || (sleep 15; brew update)
 trap 'brew cleanup && rm -rf "$(brew --cache)" "${HOME}/Library/Logs/Homebrew/*"' EXIT
 brew bundle --file="$(dirname ${(%):-%x})/Brewfile"
+
+curl --retry 4 -o /tmp/gurobi10.0.2_macos_universal2.pkg \
+  https://packages.gurobi.com/10.0/gurobi10.0.2_macos_universal2.pkg
+echo '955BB1CFA9A72B09C23AF6413A10E95F8E05A189539619495F123FF0F3C258C8  /tmp/gurobi10.0.2_macos_universal2.pkg' \
+  | sha256sum -c -
+sudo installer -pkg /tmp/gurobi10.0.2_macos_universal2.pkg -target /


### PR DESCRIPTION
Moving to a custom install similar to the install on Ubuntu removes the last remaining dependency on drake-homebrew.

Towards RobotLocomotion/drake#23280.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/346)
<!-- Reviewable:end -->
