### PR TITLE
[cache] Manage log files even more strictly

### DIFF
--- a/cache_server/README.md
+++ b/cache_server/README.md
@@ -219,7 +219,7 @@ All of the configuration options should be executed as `root`.
     # Rotate cache logs.  See the script for more information, this must be run
     # frequently since the nginx access.log can grow quite quickly.  Run it when
     # the other two jobs above are unlikely to also be running (and logging).
-    10-59/15 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/opt/cache_server/log/rotate_logs.log 2>&1
+    5-59/10 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/opt/cache_server/log/rotate_logs.log 2>&1
     ```
 
     You should be able to save and `cat /var/spool/cron/crontabs/root` to

--- a/cache_server/disk_usage.py
+++ b/cache_server/disk_usage.py
@@ -96,9 +96,11 @@ def main() -> None:
             {percent_used:.2f}% usage exceeds provided threshold of {args.threshold}%
 
             The `remove_old_files.py` cron job runs every 15 minutes (e.g., at
-            12:00, 12:15, 12:30, and 12:45).  It can take up to 5 minutes to
-            complete, please wait until the automated file removal routine is
-            complete and re-launch this cache server health check job.
+            12:00, 12:15, 12:30, and 12:45) to clean out the cache files, and
+            the `rotate_logs.py` cron job runs every 10 minutes (e.g., at 12:05,
+            12:15, 12:25, etc.) to clean out the log files. These jobs can
+            take up to 5 minutes to complete. Please wait until the automated
+            file removal routine is complete and re-launch this job.
 
             If it fails again, please start a thread in the #buildcop slack
             channel delegating to Kitware:

--- a/cache_server/logrotate_cache.conf
+++ b/cache_server/logrotate_cache.conf
@@ -1,15 +1,14 @@
-# Rotate logs if they grow past 150MB, or each month, whichever is first.
-# Note that the /opt/cache_server/log/nginx/access.log in particular grows very
-# quickly.  Logs are rotated hourly as a result, otherwise you can end up with
-# an access.log of >5GB.
+# Rotate logs if they grow past 100MB, or each week, whichever is first.
+# Note that the /opt/cache_server/log/nginx/access.log in particular grows
+# very quickly, so logs are rotated quite frequently as a result.
 #
 # Logs will be rotated 10 times and then deleted.
 #
 # Note that the cron job running this is expected to execute daily.
 "/opt/cache_server/log/*.log" "/opt/cache_server/log/nginx/*.log" {
-    monthly
+    weekly
     missingok
     rotate 10
-    size 150M
-    maxsize 150M
+    size 100M
+    maxsize 100M
 }

--- a/cache_server/rotate_logs.py
+++ b/cache_server/rotate_logs.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Rotate log files using ``logrotate`` and restart ``nginx``.
 
-This script is expected to run by cron on an hourly schedule, see the associated
-``logrotate_cache.conf`` for the ``logrotate`` command which specifies the directories
-and rules for log files being rotated.
+This script is expected to run by cron. See the associated
+``logrotate_cache.conf`` for the ``logrotate`` command which specifies the
+directories and rules for log files being rotated.
 
 After ``logrotate`` runs, however, the log files
 ``/opt/cache_server/nginx/{access,error}.log`` may have been removed.  Running


### PR DESCRIPTION
d017e60 was not sufficient, as many back-to-back merges causing lots of cache hits are overloading the disk. Change from every 15 to every 10 minutes, and limit the size from 150 MB to 100 MB.

Also, de-duplicate the language around when this job is run throughout the directory, so that updates can happen in a single location.

Closes RobotLocomotion/drake#23367.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/347)
<!-- Reviewable:end -->
