### PR TITLE
[cache] Move log files to `/cache/log/`

### DIFF
--- a/cache_server/README.md
+++ b/cache_server/README.md
@@ -65,8 +65,8 @@ By convention:
   production (e.g., cannot `git pull` new files) or get new logging information.
     - **NOTE**: this directory path is also used by
       [`health_check.bash`](./health_check.bash).
-- The logs for `nginx`, file removal, and disk monitoring are are stored in
-  `/opt/cache_server/log`.
+- The logs for `nginx`, file removal, and disk monitoring are stored in
+  `/cache/log`.
 - The build cache is written to `/cache/data`.  The [`cache.cmake`][cache_cmake]
   configuration sets as an example `DASHBOARD_REMOTE_CACHE_KEY_VERSION=v7`, so
   the action cache (ac) and content addressed storage (cas) will be stored at
@@ -96,9 +96,9 @@ All of the configuration options should be executed as `root`.
     (
         mkdir -p \
             /cache/data \
-            /opt/cache_server \
-            /opt/cache_server/log/nginx;
-        chown -R www-data:www-data /cache/data /opt/cache_server/log/nginx;
+            /cache/log/nginx;
+            /opt/cache_server;
+        chown -R www-data:www-data /cache/data /cache/log/nginx;
     )
     ```
 
@@ -203,23 +203,23 @@ All of the configuration options should be executed as `root`.
     #
     # This cache server's date / time are in America/New_York!
     # Cache pruning (https://crontab.guru/#*/15_*_*_*_*): every 15th minute.
-    */15 * * * *   /opt/cache_server/drake-ci/cache_server/remove_old_files.py auto /cache/data >>/opt/cache_server/log/remove_old_files.log 2>&1
+    */15 * * * *   /opt/cache_server/drake-ci/cache_server/remove_old_files.py auto /cache/data >>/cache/log/drake-ci/remove_old_files.log 2>&1
     #
     # Disk usage monitoring: on minute 40 (the file removal above runs on minute
     # 30, allow it to complete before checking).  Note that there is a continuous
     # cache server health check job that runs on a completely unrelated
     # schedule.  This log primarily exists as a backup for us to consult if we
     # desire to monitor how much is deleted when.
-    40 * * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/data >>/opt/cache_server/log/disk_usage_cache_data.log 2>&1
+    40 * * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/data >>/cache/log/drake-ci/disk_usage_cache_data.log 2>&1
     #
     # Additionally monitor disk usage of the root volume.  This is where the
     # logging data is stored.
-    40 * * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py / -t 80 >>/opt/cache_server/log/disk_usage_root.log 2>&1
+    40 * * * *   /opt/cache_server/drake-ci/cache_server/disk_usage.py / -t 80 >>/cache/log/drake-ci/disk_usage_root.log 2>&1
     #
     # Rotate cache logs.  See the script for more information, this must be run
     # frequently since the nginx access.log can grow quite quickly.  Run it when
     # the other two jobs above are unlikely to also be running (and logging).
-    5-59/10 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/opt/cache_server/log/rotate_logs.log 2>&1
+    5-59/10 * * * *   /opt/cache_server/drake-ci/cache_server/rotate_logs.py >>/cache/log/drake-ci/rotate_logs.log 2>&1
     ```
 
     You should be able to save and `cat /var/spool/cron/crontabs/root` to
@@ -241,7 +241,7 @@ All of the configuration options should be executed as `root`.
     have a terminal open and logged into the cache server in question.  Launch
     your experimental jenkins job parameterized with the appropriate `drake-ci`
     PR, and in the terminal on the cache server observe
-    `tail -f /opt/cache_server/log/nginx/access.log`.
+    `tail -f /cache/log/nginx/access.log`.
 
     Typically, the right job to select would be
     "default compiler, bazel, release", e.g.,

--- a/cache_server/drake_cache_server_nginx.conf
+++ b/cache_server/drake_cache_server_nginx.conf
@@ -4,8 +4,8 @@ server {
     server_name _;
 
     # Send the logging files to our own custom location.
-    access_log /opt/cache_server/log/nginx/access.log;
-    error_log /opt/cache_server/log/nginx/error.log;
+    access_log /cache/log/nginx/access.log;
+    error_log /cache/log/nginx/error.log;
 
     # Disable logging of "file not found" (do not log cache misses).
     log_not_found off;

--- a/cache_server/health_check.bash
+++ b/cache_server/health_check.bash
@@ -49,17 +49,17 @@ eval "$(ssh-agent -s)"
 # The disk_usage.py script must be run as `root` to access `/cache/data`.  Using
 # `-o StrictHostKeyChecking=no` tells ssh to accept new fingerprints
 # (~/.ssh/known_hosts does not know the cache server when this runs in CI).
-# Check disk usage for /cache/data (the real cache) ...
+# Check disk usage for `/cache/`, which stores data in `data/` and logs in `logs/`.
 timeout 120 \
     ssh \
         -o IdentitiesOnly=yes \
         -o StrictHostKeyChecking=no \
         -i "${cache_server_id_rsa_path}" \
         "root@${server_ip}" \
-        '/opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/data'
-# ... and / (which stores log files in /opt/cache_server/logs).
-# Also, be more sensitive about the disk usage threshold for this one,
-# as the drive is much smaller than /cache.
+        '/opt/cache_server/drake-ci/cache_server/disk_usage.py /cache/'
+# Also check disk usage for `/`. Theoretically, nothing is stored here besides
+# the drake-ci clone, but it's a very small disk, and it holds the root
+# filesystem, so if anything is unexpected we should know immediately.
 timeout 120 \
     ssh \
         -o IdentitiesOnly=yes \

--- a/cache_server/logrotate_cache.conf
+++ b/cache_server/logrotate_cache.conf
@@ -1,11 +1,11 @@
 # Rotate logs if they grow past 100MB, or each week, whichever is first.
-# Note that the /opt/cache_server/log/nginx/access.log in particular grows
+# Note that the /cache/log/nginx/access.log in particular grows
 # very quickly, so logs are rotated quite frequently as a result.
 #
 # Logs will be rotated 10 times and then deleted.
 #
 # Note that the cron job running this is expected to execute daily.
-"/opt/cache_server/log/*.log" "/opt/cache_server/log/nginx/*.log" {
+"/cache/log/drake-ci/*.log" "/cache/log/nginx/*.log" {
     weekly
     missingok
     rotate 10

--- a/cache_server/rotate_logs.py
+++ b/cache_server/rotate_logs.py
@@ -6,7 +6,7 @@ This script is expected to run by cron. See the associated
 directories and rules for log files being rotated.
 
 After ``logrotate`` runs, however, the log files
-``/opt/cache_server/nginx/{access,error}.log`` may have been removed.  Running
+``/cache/log/nginx/{access,error}.log`` may have been removed.  Running
 ``nginx -s reload`` will close the file handles ``nginx`` had open to the previous
 (now possibly rotated to a new filename) log files, and open new ones.  Without
 reloading, all nginx logging for logs that have been rotated will stop.
@@ -59,18 +59,17 @@ def main():
     if logrotate is None:
         error("Could not find the `logrotate` command.  Is it installed?")
 
-    # Logs are stored in /opt/cache_server/log/.  Send the logging output of the
-    # ``logrotate`` command to /opt/cache_server/logrotate.log, and then re-log that to
-    # stdout (this script should run under cron and redirect to
-    # /opt/cache_server/log/rotate_logs.log).
+    # Logs are stored in /cache/log/.  Send the logging output of the
+    # ``logrotate`` command to /cache/log/logrotate.log, and then re-log that to
+    # stdout (which should be redirected to a log file when run under cron).
     this_file_dir = Path(__file__).parent.absolute()
     logrotate_conf_path = this_file_dir / "logrotate_cache.conf"
     if not logrotate_conf_path.is_file():
         error(f"'{logrotate_conf_path}' is not a file.")
 
     # ``logrotate`` setup.
-    opt_cache_server = Path("/opt") / "cache_server"
-    logrotate_log_path = opt_cache_server / "logrotate.log"
+    cache_log = Path("/cache") / "log"
+    logrotate_log_path = cache_log / "drake-ci" / "logrotate.log"
     logrotate_log_path.unlink(missing_ok=True)
     logrotate_args = [
         logrotate,
@@ -118,7 +117,7 @@ def main():
     )
     log_stdout_stderr(systemctl_proc)
 
-    nginx_log_dir = opt_cache_server / "log" / "nginx"
+    nginx_log_dir = cache_log / "nginx"
     access_log = nginx_log_dir / "access.log"
     error_log = nginx_log_dir / "error.log"
     nginx_log_files = [access_log, error_log]


### PR DESCRIPTION
742074a was still not good enough. `/cache` has significantly more storage, so use it instead of the small `/`.

This introduces a small risk that if the cache file removal fails causing the disk to fill up, we lose the logs. However, that is unlikely, and the logs are likely unhelpful in that case anyways (especially with often they were being rotated before).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/349)
<!-- Reviewable:end -->
