### PR TITLE
Clean Jenkins workspace before jobs

### DIFF
--- a/ctest_driver_script_wrapper.bash
+++ b/ctest_driver_script_wrapper.bash
@@ -47,6 +47,14 @@ fi
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
 
+# Ensure the Jenkins workspace is cleared from previous runs.
+readonly GLOBAL_WORKSPACE="$(realpath ${WORKSPACE}/..)"
+if [[ "${GLOBAL_WORKSPACE}" == *workspace ]]; then
+    sudo find "${GLOBAL_WORKSPACE}" -mindepth 1 -maxdepth 1 \
+        -not -path "${WORKSPACE}" -not -path "${WORKSPACE}@tmp" \
+        -exec rm -rf {} +
+fi
+
 # Provision image, if required (Linux only).
 if [[ "$(uname -s)" == "Linux" && "${JOB_NAME}" =~ unprovisioned ]]; then
     sudo --preserve-env "${CI_ROOT}/setup/ubuntu/install_prereqs"


### PR DESCRIPTION
Ensure that artifacts from old jobs don't linger indefinitely on CI instances, particularly for macOS where the instance is reused across many jobs.

See also: RobotLocomotion/drake#23387.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/350)
<!-- Reviewable:end -->
