### PR TITLE
Upload doc tarballs to S3

### DIFF
--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -288,11 +288,16 @@ if(NOT DASHBOARD_FAILURE AND NOT DASHBOARD_UNSTABLE)
   set(DASHBOARD_MESSAGE "SUCCESS")
 endif()
 
-# Build and publish documentation, if requested, and if build succeeded.
+# Build, publish, and upload documentation, if requested, and if build
+# succeeded.
 if(DOCUMENTATION)
   execute_step(bazel build-documentation)
   if(DOCUMENTATION STREQUAL "publish")
     execute_step(bazel publish-documentation)
+  else()
+    execute_step(common set-package-version)
+    execute_step(bazel create-documentation-archive)
+    execute_step(bazel upload-documentation)
   endif()
 endif()
 

--- a/driver/configurations/bazel/step-create-documentation-archive.cmake
+++ b/driver/configurations/bazel/step-create-documentation-archive.cmake
@@ -1,0 +1,55 @@
+# -*- mode: cmake; -*-
+# vi: set ft=cmake:
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, Massachusetts Institute of Technology.
+# Copyright (c) 2025, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if(DASHBOARD_FAILURE OR DASHBOARD_UNSTABLE)
+  notice("CTest Status: NOT CREATING DOCUMENTATION ARCHIVE BECAUSE BAZEL BUILD WAS NOT SUCCESSFUL")
+else()
+  notice("CTest Status: CREATING DOCUMENTATION ARCHIVE")
+
+  set(DASHBOARD_DOCUMENTATION_ARCHIVE_NAME
+    "${DASHBOARD_WORKSPACE}/drake-doc-${DASHBOARD_DRAKE_VERSION}.tar.gz"
+  )
+  cmake_path(GET DASHBOARD_DOCUMENTATION_DIRECTORY
+    PARENT_PATH DOC_WORKING_DIR
+  )
+
+  execute_process(COMMAND "${CMAKE_COMMAND}" -E tar czf
+    "${DASHBOARD_DOCUMENTATION_ARCHIVE_NAME}"
+    "${DASHBOARD_DOCUMENTATION_DIRECTORY}"
+    WORKING_DIRECTORY "${DOC_WORKING_DIR}"
+    RESULT_VARIABLE TAR_RESULT_VARIABLE)
+  if(NOT TAR_RESULT_VARIABLE EQUAL 0)
+      append_step_status("DOCUMENTATION ARCHIVE CREATION" UNSTABLE)
+  endif()
+endif()

--- a/driver/configurations/bazel/step-upload-documentation.cmake
+++ b/driver/configurations/bazel/step-upload-documentation.cmake
@@ -1,0 +1,41 @@
+# -*- mode: cmake; -*-
+# vi: set ft=cmake:
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, Massachusetts Institute of Technology.
+# Copyright (c) 2025, Toyota Research Institute.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if(DASHBOARD_FAILURE OR DASHBOARD_UNSTABLE)
+  notice("CTest Status: NOT UPLOADING DOCUMENTATION ARCHIVE BECAUSE BAZEL BUILD WAS NOT SUCCESSFUL")
+else()
+  notice("CTest Status: UPLOADING DOCUMENTATION ARCHIVE")
+  aws_upload("${DASHBOARD_DOCUMENTATION_ARCHIVE_NAME}"
+    "DOCUMENTATION ARCHIVE UPLOAD")
+endif()


### PR DESCRIPTION
For non-nightly builds (which are published on the public site), it is useful for developers to be able to access the results of a documentation job, rather than having to build locally.

This will upload documentation archives to `drake-packages/drake/<continuous|experimental>/drake-doc-<version>.tar.gz`. 

Closes RobotLocomotion/drake#23329.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/351)
<!-- Reviewable:end -->
