### PR TITLE
Remove unused DRAKE_GUROBI_LICENSE_UNLIMITED

### DIFF
--- a/driver/configurations/gurobi.cmake
+++ b/driver/configurations/gurobi.cmake
@@ -61,6 +61,3 @@ endif()
 
 # Always set environment variable so remote caches may be shared.
 set(ENV{GRB_LICENSE_FILE} "${GRB_LICENSE_FILE}")
-
-# Run Gurobi tests in parallel in the CI
-set(ENV{DRAKE_GUROBI_LICENSE_UNLIMITED} 1)


### PR DESCRIPTION
Unused as of https://github.com/RobotLocomotion/drake/pull/24382.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/415)
<!-- Reviewable:end -->
