### PR TITLE
Only install Gurobi on Ubuntu x86_64

### DIFF
--- a/setup/ubuntu/install_prereqs
+++ b/setup/ubuntu/install_prereqs
@@ -133,8 +133,11 @@ systemctl --now --quiet enable /lib/systemd/system/xvfb.service
 systemctl enable chrony
 systemctl start  chrony
 
-install_gurobi \
-  'https://packages.gurobi.com/13.0/gurobi13.0.1_linux64.tar.gz' \
-  '/opt/gurobi1301' \
-  'ec623217ac5fa0657799a752ed7c02b2141fbb9c0ff34129d6e1f8c9a8fe4ed8' \
-  'c18d09d252e1287cdb421c6984de21811907e02cdbe9db7890598453e563ab7b'
+# Drake does not currently support Gurobi on Ubuntu aarch64.
+if [[ "$(arch)" == "x86_64" ]]; then
+  install_gurobi \
+    'https://packages.gurobi.com/13.0/gurobi13.0.1_linux64.tar.gz' \
+    '/opt/gurobi1301' \
+    'ec623217ac5fa0657799a752ed7c02b2141fbb9c0ff34129d6e1f8c9a8fe4ed8' \
+    'c18d09d252e1287cdb421c6984de21811907e02cdbe9db7890598453e563ab7b'
+fi


### PR DESCRIPTION
See https://github.com/RobotLocomotion/drake/issues/24297#issuecomment-4226951570 and https://docs.gurobi.com/projects/optimizer/en/current/reference/releasenotes/platforms.html. While Gurobi 13 does have Linux arm64 support, it's not with the binary we're currently installing, and Drake in the near future doesn't plan to support it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/423)
<!-- Reviewable:end -->
