### PR TITLE
Remove dead flags / settings

### DIFF
--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -43,12 +43,6 @@ else()
   set(DASHBOARD_JOBS 1)
 endif()
 
-if(VERBOSE)
-  set(DASHBOARD_SUBCOMMANDS "yes")
-else()
-  set(DASHBOARD_SUBCOMMANDS "no")
-endif()
-
 include(${DASHBOARD_DRIVER_DIR}/configurations/cache.cmake)
 
 if(REMOTE_CACHE)

--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -17,18 +17,6 @@ if (PACKAGE)
   set(DASHBOARD_SUBMIT OFF)
 endif()
 
-set(DASHBOARD_CXX_FLAGS)
-if(DEFINED ENV{TERM})
-  if(COMPILER STREQUAL "clang")
-    set(DASHBOARD_CXX_FLAGS "-fcolor-diagnostics ${DASHBOARD_CXX_FLAGS}")
-  elseif(COMPILER STREQUAL "gcc")
-    set(DASHBOARD_CXX_FLAGS "-fdiagnostics-color=always ${DASHBOARD_CXX_FLAGS}")
-  endif()
-  set(DASHBOARD_COLOR_MAKEFILE ON)
-else()
-  set(DASHBOARD_COLOR_MAKEFILE OFF)
-endif()
-
 # Set up build configuration
 set(CTEST_CONFIGURATION_TYPE "${DASHBOARD_CONFIGURATION_TYPE}")
 set(CTEST_TEST_TIMEOUT 300)
@@ -38,16 +26,7 @@ include(${DASHBOARD_DRIVER_DIR}/configurations/gurobi.cmake)
 include(${DASHBOARD_DRIVER_DIR}/configurations/mosek.cmake)
 include(${DASHBOARD_DRIVER_DIR}/configurations/snopt.cmake)
 
-if(VERBOSE)
-  set(DASHBOARD_VERBOSE_MAKEFILE ON)
-else()
-  set(DASHBOARD_VERBOSE_MAKEFILE OFF)
-endif()
-
-cache_append(CMAKE_COLOR_MAKEFILE BOOL ${DASHBOARD_COLOR_MAKEFILE})
-cache_append(CMAKE_CXX_FLAGS STRING ${DASHBOARD_CXX_FLAGS})
 cache_append(CMAKE_INSTALL_PREFIX PATH ${DASHBOARD_INSTALL_PREFIX})
-cache_append(CMAKE_VERBOSE_MAKEFILE BOOL ${DASHBOARD_VERBOSE_MAKEFILE})
 cache_append(DRAKE_CI_ENABLE_PACKAGING BOOL ${PACKAGE})
 cache_append(DRAKE_CI_ENABLE_EVERYTHING BOOL ${EVERYTHING})
 
@@ -97,10 +76,7 @@ report_configuration("
   ====================================
   CMAKE_VERSION
   ==================================== >DASHBOARD_ <CMAKE_
-  COLOR_MAKEFILE
-  CXX_FLAGS
   INSTALL_PREFIX
-  VERBOSE_MAKEFILE
   ====================================
   CTEST_BUILD_NAME(DASHBOARD_JOB_NAME)
   CTEST_BINARY_DIRECTORY

--- a/driver/configurations/wheel.cmake
+++ b/driver/configurations/wheel.cmake
@@ -23,12 +23,6 @@ else()
   set(DASHBOARD_EXPERIMENTAL_SCALE_TIMEOUTS 1.0)
 endif()
 
-if(VERBOSE)
-  set(DASHBOARD_SUBCOMMANDS "yes")
-else()
-  set(DASHBOARD_SUBCOMMANDS "no")
-endif()
-
 include(${DASHBOARD_DRIVER_DIR}/configurations/aws.cmake)
 
 # Set package version

--- a/driver/environment.cmake
+++ b/driver/environment.cmake
@@ -173,13 +173,6 @@ else()
   set(DOCKER OFF)
 endif()
 
-string(STRIP "$ENV{verbose}" VERBOSE)
-if(VERBOSE)
-  set(VERBOSE ON)
-else()
-  set(VERBOSE OFF)
-endif()
-
 # Set the source tree
 set(DASHBOARD_SOURCE_DIRECTORY "${DASHBOARD_WORKSPACE}/src")
 

--- a/tools/user.bazelrc.in
+++ b/tools/user.bazelrc.in
@@ -11,7 +11,6 @@ build --host_copt=@DASHBOARD_COPT@
 build --http_timeout_scaling=@DASHBOARD_EXPERIMENTAL_SCALE_TIMEOUTS@
 build --jobs=@DASHBOARD_JOBS@
 build --keep_going=yes
-build --subcommands=@DASHBOARD_SUBCOMMANDS@
 build --test_env=GRB_LICENSE_FILE
 build --test_env=MOSEKLM_LICENSE_FILE
 build --experimental_repository_downloader_retries=5


### PR DESCRIPTION
I was working on removing `CXX_FLAGS` and noticed more dead stuff nearby.  I think some of this dates back to 2016 when we actually had a real CMake build (where CMake built the code).

+a:@tyler-yankee for review/testing, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/428)
<!-- Reviewable:end -->
