### PR TITLE
Remove CXX_COMMAND

### DIFF
--- a/driver/compiler.cmake
+++ b/driver/compiler.cmake
@@ -3,17 +3,14 @@
 
 if(APPLE)
   set(DASHBOARD_CC_COMMAND "/usr/bin/clang")
-  set(DASHBOARD_CXX_COMMAND "/usr/bin/clang++")
 else()
   if(GENERATOR STREQUAL "bazel" AND COMPILER STREQUAL "clang")
     # Ask Bazel which Clang it's using.
-    determine_compiler(DASHBOARD_CC_COMMAND DASHBOARD_CXX_COMMAND)
+    determine_compiler(DASHBOARD_CC_COMMAND)
   else()
     set(DASHBOARD_CC_COMMAND "/usr/bin/gcc")
-    set(DASHBOARD_CXX_COMMAND "/usr/bin/g++")
   endif()
 endif()
 compiler_version_string("${DASHBOARD_CC_COMMAND}" DASHBOARD_CC_VERSION_STRING)
-compiler_version_string("${DASHBOARD_CXX_COMMAND}" DASHBOARD_CXX_VERSION_STRING)
 
 string(TOUPPER "${COMPILER}" COMPILER_UPPER)

--- a/driver/configurations/bazel.cmake
+++ b/driver/configurations/bazel.cmake
@@ -121,8 +121,6 @@ report_configuration("
   ==================================== >DASHBOARD_
   CC_COMMAND
   CC_VERSION_STRING
-  CXX_COMMAND
-  CXX_VERSION_STRING
   ==================================== >DASHBOARD_
   UNIX_DISTRIBUTION
   UNIX_DISTRIBUTION_CODE_NAME

--- a/driver/configurations/cmake.cmake
+++ b/driver/configurations/cmake.cmake
@@ -66,8 +66,6 @@ report_configuration("
   ==================================== >DASHBOARD_
   CC_COMMAND
   CC_VERSION_STRING
-  CXX_COMMAND
-  CXX_VERSION_STRING
   ==================================== >DASHBOARD_
   UNIX_DISTRIBUTION
   UNIX_DISTRIBUTION_CODE_NAME

--- a/driver/configurations/wheel.cmake
+++ b/driver/configurations/wheel.cmake
@@ -33,8 +33,6 @@ report_configuration("
   ==================================== >DASHBOARD_
   CC_COMMAND
   CC_VERSION_STRING
-  CXX_COMMAND
-  CXX_VERSION_STRING
   ====================================
   CMAKE_VERSION
   ====================================

--- a/driver/functions.cmake
+++ b/driver/functions.cmake
@@ -338,7 +338,7 @@ endmacro()
 # invoking tooling within Drake. This is used conditionally in compiler.cmake
 # to select the compiler for the current build.
 #------------------------------------------------------------------------------
-function(determine_compiler OUTPUT_CC_VARIABLE OUTPUT_CXX_VARIABLE)
+function(determine_compiler OUTPUT_CC_VARIABLE)
   # Query what compiler is specified by `--config=${COMPILER}`.
   set(COMPILER_CONFIG_ARGS
     run --config=${COMPILER}
@@ -359,11 +359,11 @@ function(determine_compiler OUTPUT_CC_VARIABLE OUTPUT_CXX_VARIABLE)
   execute_process(COMMAND ${DASHBOARD_BAZEL_COMMAND} clean
     WORKING_DIRECTORY "${DASHBOARD_SOURCE_DIRECTORY}")
 
-  # Extract the compiler (CC, CXX) names.
+  # Extract the compiler (CC) value.
   STRING(REPLACE "\n" ";" COMPILER_CONFIG_OUTPUT "${COMPILER_CONFIG_OUTPUT}")
   foreach(COMPILER_CONFIG_ENTRY IN LISTS COMPILER_CONFIG_OUTPUT)
-    if("${COMPILER_CONFIG_ENTRY}" MATCHES "^([A-Z]+)=(.*)$")
-      set(${CMAKE_MATCH_1}_COMMAND "${CMAKE_MATCH_2}")
+    if("${COMPILER_CONFIG_ENTRY}" MATCHES "^CC=(.*)$")
+      set(CC_COMMAND "${CMAKE_MATCH_1}")
     endif()
   endforeach()
 
@@ -371,12 +371,8 @@ function(determine_compiler OUTPUT_CC_VARIABLE OUTPUT_CXX_VARIABLE)
   if("${CC_COMMAND}" STREQUAL "")
     fatal("compiler configuration (CC) could not be obtained")
   endif()
-  if("${CXX_COMMAND}" STREQUAL "")
-    fatal("compiler configuration (CXX) could not be obtained")
-  endif()
 
   set(${OUTPUT_CC_VARIABLE} "${CC_COMMAND}" PARENT_SCOPE)
-  set(${OUTPUT_CXX_VARIABLE} "${CXX_COMMAND}" PARENT_SCOPE)
 endfunction()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The remote cache only uses CC_COMMAND for the key, not CXX_COMMAND.

The only thing it was doing is showing up in the log; nothing actually used it as of #419 or thereabouts.

+a:@tyler-yankee for review/testing please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/429)
<!-- Reviewable:end -->
