### PR TITLE
Initialize unprovisioned images without requiring dpkg-dev

### DIFF
--- a/setup/ubuntu/ami_init_script
+++ b/setup/ubuntu/ami_init_script
@@ -29,8 +29,13 @@ apt-get install --no-install-recommends \
   ${packages}
 
 # Set the version of Java to match Jenkins.
-update-java-alternatives --jre-headless -s \
-  java-1.21.0-openjdk-$(dpkg-architecture -qDEB_HOST_ARCH)
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  update-java-alternatives --jre-headless -s \
+    java-1.21.0-openjdk-arm64
+else
+  update-java-alternatives --jre-headless -s \
+    java-1.21.0-openjdk-amd64
+fi
 
 groupadd docker
 usermod -a -G docker ubuntu


### PR DESCRIPTION
`dpkg-architecture` is convenient, but `dpkg-dev` has an unnecessarily hefty list of dependencies for our unprovisioned images. Use `uname -m` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/431)
<!-- Reviewable:end -->
