### PR TITLE
Standardize binary tarball architecture naming

### DIFF
--- a/driver/architecture.cmake
+++ b/driver/architecture.cmake
@@ -1,19 +1,22 @@
 # -*- mode: cmake; -*-
 # vi: set ft=cmake:
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  # Check we have an architecture variant enabled; if not, the output is empty.
+if(NOT APPLE)
+  # Use the first of Architecture-Variant or Architecture that is defined,
+  # since the former isn't always available/applicable.
   execute_process(
-      COMMAND "dpkg-query" "--show" "--showformat=\${Architecture-Variant}" "libc6"
-      OUTPUT_VARIABLE DASHBOARD_DEB_ARCH
-      COMMAND_ECHO NONE
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(NOT DASHBOARD_DEB_ARCH)
-    set(DASHBOARD_DEB_ARCH "amd64")
+    COMMAND
+      "dpkg-query" "--show"
+      [==[--showformat=${Architecture-Variant}\n${Architecture}\n]==]
+      "libc6"
+    COMMAND
+      "grep" "-m" "1" "."
+    OUTPUT_VARIABLE DASHBOARD_DEB_ARCH
+    RESULT_VARIABLE DASHBOARD_DEB_ARCH_RESULT
+    ERROR_VARIABLE DASHBOARD_DEB_ARCH_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (NOT DASHBOARD_DEB_ARCH_RESULT EQUAL 0 OR DASHBOARD_DEB_ARCH STREQUAL "")
+    fatal("Unable to determine architecture: ${DASHBOARD_DEB_ARCH_ERROR}")
   endif()
-elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" OR
-  CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
-  set(DASHBOARD_DEB_ARCH "arm64")
-else()
-  fatal("Unable to determine architecture, or unsupported: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 endif()

--- a/driver/configurations/cmake/step-create-package-archive.cmake
+++ b/driver/configurations/cmake/step-create-package-archive.cmake
@@ -8,13 +8,12 @@ else()
   if(NOT DASHBOARD_UNSTABLE)
     if(APPLE)
       set(DASHBOARD_PACKAGE_ARCHIVE_DISTRIBUTION mac-arm64)
-    elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
-      set(DASHBOARD_PACKAGE_ARCHIVE_DISTRIBUTION "${DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME}-aarch64")
     else()
-      # For Resolute (and newer), we incorporate the architecture in the package
-      # name when running on amd64. For Noble (and prior, none of which are in
-      # CI anymore), we do NOT incorporate it.
-      if(DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME STREQUAL "noble")
+      # For compatibility reasons, our Noble amd64 binaries are named plainly
+      # without any architecture information. For all other binaries moving
+      # forward (e.g., Noble arm64, and all Resolute), incorporate the
+      # architecture and variant as applicable in all package names.
+      if(DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME STREQUAL "noble" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
         set(DASHBOARD_PACKAGE_ARCHIVE_DISTRIBUTION "${DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME}")
       else()
         set(DASHBOARD_PACKAGE_ARCHIVE_DISTRIBUTION "${DASHBOARD_UNIX_DISTRIBUTION_CODE_NAME}-${DASHBOARD_DEB_ARCH}")


### PR DESCRIPTION
The convention established for Ubuntu arm64 packages in commit d3244f6 to use `uname -m` is no longer sufficient in the context of architecture variants as of Ubuntu 26.04 and beyond, since this command doesn't indicate the variant but the resulting binaries are ABI-incompatible between variants.

Instead, re-spell our binary tarballs to respect `dpkg` conventions, and incorporate the variant information, following the approach from commit 867a1e6. This also results in consistent naming between the tarballs and `.deb` packages.

Noble x86_64 binaries are untouched for compatibility.

Towards RobotLocomotion/drake#24512.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/433)
<!-- Reviewable:end -->
