### PR TITLE
Rename Linux arm jobs to arm64

### DIFF
--- a/jenkins/vars/utils.groovy
+++ b/jenkins/vars/utils.groovy
@@ -174,7 +174,7 @@ def addCDashBadge() {
  * @return the node label
  */
 def getNodeLabel() {
-  def pattern = ~/^((linux(-arm)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
+  def pattern = ~/^((linux(-arm64)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
   def match = env.JOB_NAME =~ pattern
 
   if (match.find()) {


### PR DESCRIPTION
Using the literal name attached to our binary releases simplifies packaging logic, and prepares for future job changes which incorporate additional architecture variants on Ubuntu Resolute.

This will be accompanied by a change to our Jenkins settings to use the new `linux-arm64-(noble|resolute)-unprovisioned` spelling for EC2 node labels.

Towards RobotLocomotion/drake#24505.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/437)
<!-- Reviewable:end -->
