### PR TITLE
Remove superfluous Homebrew shellenv setup

### DIFF
--- a/setup/mac/ami_init_script
+++ b/setup/mac/ami_init_script
@@ -38,15 +38,6 @@ fi
 feedback "Fixing Homebrew permissions..."
 sudo chown -R $(whoami) "${brew_prefix}"
 
-feedback "Running Homebrew post-installation steps..."
-readonly brew_eval_command="eval \"\$(${brew_prefix} shellenv)\""
-for shell_rc in ( "${HOME}/.zshrc" "${HOME}/.bashrc" ); do
-  if [ -f "${shell_rc}" ]; then
-    grep -qF "${brew_eval_command}" "${shell_rc}" || \
-      echo "${brew_eval_command}" >> "${shell_rc}"
-  fi
-done
-
 # N.B. Gurobi requires Rosetta 2 to run on ARM (despite providing a "universal2"
 # pkg file). We should investigate whether this can be removed with future
 # versions of Gurobi.


### PR DESCRIPTION
The EC2 AMIs come with this work already done for us, and the old code was broken anyway. For context, see #422.

By "for us", I mean the following in our `~/.zshrc`. (`~/.bashrc` does not exist.)

```
# For Homebrew
export HOMEBREW_PREFIX="/opt/homebrew"
export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
export HOMEBREW_REPOSITORY="/opt/homebrew"
export HOMEBREW_SHELLENV_PREFIX="/opt/homebrew"
export PATH="/opt/homebrew/bin:/opt/homebrew/sbin${PATH+:$PATH}"
export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:"
export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}" 
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/441)
<!-- Reviewable:end -->
