### PR TITLE
Try --remote_download_outputs=minimal again

### DIFF
--- a/tools/remote.bazelrc.in
+++ b/tools/remote.bazelrc.in
@@ -1,6 +1,9 @@
 # -*- bazelrc -*-
 
-build --remote_download_outputs=all
+build --remote_download_outputs=minimal
+# Drake has its own debug-specific setting for this flag, which we must
+# override.
+build:debug --remote_download_outputs=minimal
 build --experimental_remote_cache_lease_extension=yes
 build --experimental_remote_cache_ttl=30m
 build --remote_accept_cached=@DASHBOARD_REMOTE_ACCEPT_CACHED@


### PR DESCRIPTION
This is now the third try after #296 and #323 were reverted soon after committing. Drake's current Bazel version 9.2.0 may lead to different behavior.

Towards robotlocomotion/drake#21121.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/443)
<!-- Reviewable:end -->
