### PR TITLE
Fix filename matching for AWS uploads of nanobind binaries

### DIFF
--- a/tools/pip_index_url.py
+++ b/tools/pip_index_url.py
@@ -42,12 +42,23 @@ def main() -> None:
     bucket = s3.Bucket(bucket_name)
 
     # Query the drake-packages bucket for drake/nightly/... wheel files from
-    # the past 48 days that are not in Glacier storage. The files are named
-    # like `drake-0.0.20230830-cp310-cp310-manylinux_2_31_x86_64.whl`.
+    # the past 48 days that are not in Glacier storage.
+    #
+    # See the python.org binary distribution format for the naming conventions
+    # that drake follows:
+    # https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format.
+    # In general, it's:
+    #   drake-<version>-cpNNN-(cpNNN|abi3)-<platform>.whl
+    # For example, on Linux, we may produce:
+    #   drake-0.0.20260812a1-cp312-abi3-manylinux_2_34_x86_64.whl
+    # for an abi3, glibc 2.34, x86_64 wheel built on 2026-08-12. "a1" denotes
+    # our "alpha" nanobind releases. Alternatively, there may be:
+    #   drake-0.0.20260812-cp314-cp314-manylinux_2_34_aarch64.whl
+    # for a Python 3.14-specific wheel on aarch64.
     wheels: list[Wheel] = []
     print(f"==> Querying {bucket_name} objects ...")
     days_back = 48
-    version_re = re.compile(r"^drake-0\.0\.([0-9]{8})-cp3([0-9]{1,2})-.*")
+    version_re = re.compile(r"^drake-0\.0\.([0-9]{8})(a1)?-cp3([0-9]{1,2})-.*")
     for obj in bucket.objects.filter(Prefix="drake/nightly/"):
         if obj.storage_class != "STANDARD":
             continue
@@ -58,7 +69,7 @@ def main() -> None:
         # Parse the version numbers.
         match = version_re.match(Path(obj.key).name)
         assert match is not None, obj.key
-        yyyymmdd, py_minor = match.groups()
+        yyyymmdd, _, py_minor = match.groups()
         # Check whether the date is sufficiently new.
         date = datetime.date(
             year=int(yyyymmdd[:4]),

--- a/tools/upload-to-aws.py
+++ b/tools/upload-to-aws.py
@@ -149,15 +149,18 @@ def upload_artifacts(options):
         # Names are expected too like like one of:
         #
         # TGZ:
-        #   drake-<YYYYMMDD>-<codename>.tar.gz (nightly)
-        #   drake-<YYYYMMDDHHMMSS>-<hash>-<codename>.tar.gz
+        #   drake-0.0.YYYYMMDD[-nb]-<codename>.tar.gz (nightly)
+        #   drake-0.0.YYYYMMDD.HHMMSS+git<commit>[-nb]-<codename>.tar.gz
         # Deb:
-        #   drake-dev_0.0.<YYYYMMDD>-1_<arch>-<codename>.deb (nightly)
-        #   drake-dev_0.0.<YYYYMMDDHHMMSS>-<commit>-1_<arch>-<codename>.deb
+        #   drake-dev_0.0.YYYYMMDD[-nb]-1_<arch>-<codename>.deb (nightly)
+        #   drake-dev_0.0.YYYYMMDD.HHMMSS+git<commit>[-nb]-1_<arch>-<codename>.deb
         # Wheel:
-        #   drake-0.0.YYYY.M.D.h.m.s+git<commit>-cp39-cp39-<platform>.whl
+        #   drake-0.0.YYYYMMDDD[a1]-cp312-cp312-<platform>.whl (nightly)
+        #   drake-0.0.YYYYMMDDD.HHMMSS[a1]+git<commit>-cp312-cp312-<platform>.whl
         # Generally:
-        #   drake-[dev_]<version>[-<commit>]-<stuff>
+        #   drake-[dev_]<version>[+git<commit>]-<stuff>
+        # The optional "nb" or "a1" components denote our nanobind alpha
+        # artifacts.
         #
         # A 'latest' artifact should preserve '<stuff>' unaltered, but replace
         # the version/date/sha with 'latest'. This regex matches the above and


### PR DESCRIPTION
We now include an "a1" version component in all wheel flavors (nightly, continuous, experimental, staging) to denote the use of nanobind, and are soon to promote tgz's and deb's to nightly, which will include the "-nb" component previously established for experimental nanobind packaging. For the former, update the nightly artifact extraction for our PIP index URL to correctly match the new naming convention.

While we're here, clean up the previous comments by adding more details and improving consistency.

Towards robotlocomotion/drake#24739.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/447)
<!-- Reviewable:end -->
