### PR TITLE
Add a dry-run mode to pip_index_url

### DIFF
--- a/driver/configurations/wheel/step-upload-pip-index-url.cmake
+++ b/driver/configurations/wheel/step-upload-pip-index-url.cmake
@@ -1,14 +1,9 @@
 # -*- mode: cmake; -*-
 # vi: set ft=cmake:
 
-# This step should only be executing after a nightly wheel build (for any
-# distribution) is complete.  Experimental / staging builds should NOT
-# regenerate the pip nightly index.
-if(DASHBOARD_GROUP STREQUAL "nightly")
-  if(DASHBOARD_FAILURE OR DASHBOARD_UNSTABLE)
-    notice("CTest Status: NOT GENERATING PIP INDEX URL BECAUSE WHEEL BUILD WAS NOT SUCCESSFUL")
-  else()
-    notice("CTest Status: GENERATING PIP INDEX URL")
-    generate_pip_index_url()
-  endif()
+if(DASHBOARD_FAILURE OR DASHBOARD_UNSTABLE)
+  notice("CTest Status: NOT GENERATING PIP INDEX URL BECAUSE WHEEL BUILD WAS NOT SUCCESSFUL")
+else()
+  notice("CTest Status: GENERATING PIP INDEX URL")
+  generate_pip_index_url()
 endif()

--- a/driver/functions.cmake
+++ b/driver/functions.cmake
@@ -261,8 +261,15 @@ macro(generate_pip_index_url)
       COMMAND "${venv}/bin/pip" install boto3
       RESULT_VARIABLE DASHBOARD_PYTHON_PIP_BOTO3_RESULT_VARIABLE)
     if(DASHBOARD_PYTHON_PIP_BOTO3_RESULT_VARIABLE EQUAL 0)
+      set(pip_index_cmd
+        "${venv}/bin/python3" "${DASHBOARD_TOOLS_DIR}/pip_index_url.py"
+      )
+      if(NOT DASHBOARD_GROUP STREQUAL "nightly")
+        # ONLY nightly jobs should ever populate the pip index.
+        list(APPEND pip_index_cmd "--dry-run")
+      endif()
       execute_process(
-        COMMAND "${venv}/bin/python3" "${DASHBOARD_TOOLS_DIR}/pip_index_url.py"
+        COMMAND ${pip_index_cmd}
         RESULT_VARIABLE DASHBOARD_PIP_INDEX_URL_RESULT_VARIABLE)
       if(NOT DASHBOARD_PIP_INDEX_URL_RESULT_VARIABLE EQUAL 0)
         append_step_status("PIP INDEX URL" UNSTABLE)
@@ -274,6 +281,7 @@ macro(generate_pip_index_url)
     append_step_status("PIP INDEX URL VENV CREATION" UNSTABLE)
   endif()
   unset(venv)
+  unset(pip_index_cmd)
 endmacro()
 
 #------------------------------------------------------------------------------

--- a/tools/pip_index_url.py
+++ b/tools/pip_index_url.py
@@ -16,10 +16,12 @@ NOTE: to develop locally, you must have your ~/.aws/config and
 """
 from __future__ import annotations
 
+import argparse
 import datetime
 import io
 import operator
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -34,7 +36,15 @@ class Wheel:
     sha512: str | None = None
 
 
-def main() -> None:
+def main(args=None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Generate the index without uploading to S3',
+    )
+    options = parser.parse_args(args)
+
     # Log in to s3.
     print("==> Logging in to s3 ...")
     s3 = boto3.resource("s3")
@@ -139,27 +149,28 @@ def main() -> None:
     html.seek(0)
 
     # Upload the index.html to the s3 bucket.
-    s3_key = "whl/nightly/drake/index.html"
-    print(f"==> Uploading to s3://{bucket_name}/{s3_key} ...")
-    s3.meta.client.upload_fileobj(
-        html,
-        bucket_name,
-        s3_key,
-        ExtraArgs={
-            # The Max-Age for browser caches (among other tools).  We desire it
-            # to expire fairly quickly, the default is 24 hours but 30 minutes
-            # will force tools to reload the data more quickly.
-            "CacheControl": "max-age=1800",  # 30 minutes in seconds
-            # Make sure it is available as an HTML document, otherwise browsers
-            # will just download the file and pip cannot use it.
-            "ContentType": "text/html",  # Default is binary/octet-stream
-            "StorageClass": "STANDARD",
-            "ACL": "public-read",
-        },
-    )
+    if not options.dry_run:
+        s3_key = "whl/nightly/drake/index.html"
+        print(f"==> Uploading to s3://{bucket_name}/{s3_key} ...")
+        s3.meta.client.upload_fileobj(
+            html,
+            bucket_name,
+            s3_key,
+            ExtraArgs={
+                # The Max-Age for browser caches (among other tools).  We desire it
+                # to expire fairly quickly, the default is 24 hours but 30 minutes
+                # will force tools to reload the data more quickly.
+                "CacheControl": "max-age=1800",  # 30 minutes in seconds
+                # Make sure it is available as an HTML document, otherwise browsers
+                # will just download the file and pip cannot use it.
+                "ContentType": "text/html",  # Default is binary/octet-stream
+                "StorageClass": "STANDARD",
+                "ACL": "public-read",
+            },
+        )
 
     print("==> DONE!")
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
We can now run this under the non-nightly flavors (and just avoid the actual S3 update), improving consistency and catching errors sooner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ci/448)
<!-- Reviewable:end -->
